### PR TITLE
Adapt code for multinode torchrun

### DIFF
--- a/dinov2/configs/ssl_default_config.yaml
+++ b/dinov2/configs/ssl_default_config.yaml
@@ -65,6 +65,9 @@ train:
   saveckp_freq: 20
   seed: 0
   num_workers: 10
+  pin_memory: true
+  prefetch_factor: 2
+  persistent_workers: false
   OFFICIAL_EPOCH_LENGTH: 1250
   cache_dataset: true
   centering: "centering" # or "sinkhorn_knopp"

--- a/dinov2/data/loaders.py
+++ b/dinov2/data/loaders.py
@@ -175,6 +175,8 @@ def make_data_loader(
     sampler_advance: int = 0,
     drop_last: bool = True,
     persistent_workers: bool = False,
+    pin_memory: bool = True,
+    prefetch_factor: Optional[int] = None,
     collate_fn: Optional[Callable[[List[T]], Any]] = None,
 ):
     """
@@ -191,6 +193,8 @@ def make_data_loader(
         sampler_advance: How many samples to skip (when applicable).
         drop_last: Whether the last non-full batch of data should be dropped.
         persistent_workers: maintain the workers Dataset instances alive after a dataset has been consumed once.
+        pin_memory: whether to pin memory for faster host-to-device transfers.
+        prefetch_factor: number of batches prefetched per worker (requires num_workers > 0).
         collate_fn: Function that performs batch collation
     """
 
@@ -204,15 +208,20 @@ def make_data_loader(
     )
 
     logger.info("using PyTorch data loader")
+    extra_loader_kwargs = {}
+    if prefetch_factor is not None and num_workers > 0:
+        extra_loader_kwargs["prefetch_factor"] = prefetch_factor
+
     data_loader = torch.utils.data.DataLoader(
         dataset,
         sampler=sampler,
         batch_size=batch_size,
         num_workers=num_workers,
-        pin_memory=True,
+        pin_memory=pin_memory,
         drop_last=drop_last,
         persistent_workers=persistent_workers,
         collate_fn=collate_fn,
+        **extra_loader_kwargs,
     )
 
     try:

--- a/dinov2/train/train.py
+++ b/dinov2/train/train.py
@@ -207,6 +207,9 @@ def do_train(cfg, model, resume=False):
         sampler_type=sampler_type,
         sampler_advance=0,  # TODO(qas): fix this -- start_iter * cfg.train.batch_size_per_gpu,
         drop_last=True,
+        persistent_workers=cfg.train.persistent_workers,
+        pin_memory=cfg.train.pin_memory,
+        prefetch_factor=cfg.train.prefetch_factor,
         collate_fn=collate_fn,
     )
 


### PR DESCRIPTION
Add configurable DataLoader memory knobs to mitigate `OSError: [Errno 12] Cannot allocate memory` during training.

This change allows users to tune host memory usage by controlling `pin_memory`, `prefetch_factor`, and `persistent_workers` for DataLoaders, addressing a memory allocation error encountered during multi-node training.

---
<a href="https://cursor.com/background-agent?bcId=bc-fcc6b677-a8cb-4cdd-85ff-abd2a6057bc0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fcc6b677-a8cb-4cdd-85ff-abd2a6057bc0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

