### PR TITLE
Distribute model layers across four GPUs

### DIFF
--- a/dinov2/configs/ssl_default_config.yaml
+++ b/dinov2/configs/ssl_default_config.yaml
@@ -85,6 +85,8 @@ train:
 student:
   arch: vit_large
   patch_size: 16
+  # set is_3d: true for 3D inputs (and then use tuple patch_size, e.g. [2,16,16])
+  is_3d: false
   drop_path_rate: 0.3
   layerscale: 1.0e-05
   drop_path_uniform: true

--- a/dinov2/configs/ssl_default_config.yaml
+++ b/dinov2/configs/ssl_default_config.yaml
@@ -126,6 +126,12 @@ student:
   # Optional model-parallel device list; example to use 4 GPUs on one node
   # Set to [] or remove to disable model parallel.
   mp_devices: [0, 1, 2, 3]
+  lora:
+    enabled: false
+    r: 8
+    alpha: 16.0
+    dropout: 0.0
+    targets: ["qkv", "proj", "fc1", "fc2"]
 teacher:
   momentum_teacher: 0.992
   final_momentum_teacher: 1

--- a/dinov2/configs/ssl_default_config.yaml
+++ b/dinov2/configs/ssl_default_config.yaml
@@ -62,8 +62,12 @@ ibot:
   freq_mask:
     enabled: false
     prob: 0.5
-    low: 0.05     # normalized low cutoff (0-0.5)
-    high: 0.25    # normalized high cutoff (0-0.5)
+    # Either specify fixed cutoffs (low/high) or ranges below for per-sample sampling
+    low: 0.05        # normalized low cutoff (0..0.5)
+    high: 0.25       # normalized high cutoff (0..0.5)
+    per_sample: false
+    low_range: [0.02, 0.10]   # used when per_sample: true
+    high_range: [0.20, 0.40]  # used when per_sample: true
     mode: bandpass  # bandpass|lowpass|highpass
 train:
   batch_size_per_gpu: 64

--- a/dinov2/configs/ssl_default_config.yaml
+++ b/dinov2/configs/ssl_default_config.yaml
@@ -93,6 +93,13 @@ train:
     chunks: {sample: 1024}
     to_chw: true
     normalize: true
+  # Tiling for large 2D/3D inputs
+  tiling:
+    enabled: false
+    is_3d: false
+    tile_size: [512, 512]      # or [D,H,W] for 3D
+    stride: [512, 512]         # or [D,H,W] for 3D
+    drop_last_tiles: true
   # Performance features
   torch_compile: false
   torch_compile_mode: reduce-overhead  # reduce-overhead|max-autotune

--- a/dinov2/configs/ssl_default_config.yaml
+++ b/dinov2/configs/ssl_default_config.yaml
@@ -83,6 +83,9 @@ student:
   num_register_tokens: 0
   interpolate_antialias: false
   interpolate_offset: 0.1
+  # Optional model-parallel device list; example to use 4 GPUs on one node
+  # Set to [] or remove to disable model parallel.
+  mp_devices: [0, 1, 2, 3]
 teacher:
   momentum_teacher: 0.992
   final_momentum_teacher: 1

--- a/dinov2/configs/ssl_default_config.yaml
+++ b/dinov2/configs/ssl_default_config.yaml
@@ -73,6 +73,15 @@ train:
   prefetch_factor: 2
   persistent_workers: true
   shm_sharing_strategy: file_system  # or 'file_descriptor'
+  # Optional xarray/xbatcher loader
+  use_xarray: false
+  xarray:
+    dataset_path: ''  # path to Zarr/NetCDF dataset
+    image_var: 'image'  # [H,W,C] or [C,H,W]
+    target_var: ''
+    chunks: {sample: 1024}
+    to_chw: true
+    normalize: true
 student:
   arch: vit_large
   patch_size: 16

--- a/dinov2/configs/ssl_default_config.yaml
+++ b/dinov2/configs/ssl_default_config.yaml
@@ -58,6 +58,13 @@ ibot:
   head_bottleneck_dim: 256
   head_nlayers: 3
   head_hidden_dim: 2048
+  # Optional frequency-domain masking for inputs (applied to crops)
+  freq_mask:
+    enabled: false
+    prob: 0.5
+    low: 0.05     # normalized low cutoff (0-0.5)
+    high: 0.25    # normalized high cutoff (0-0.5)
+    mode: bandpass  # bandpass|lowpass|highpass
 train:
   batch_size_per_gpu: 64
   dataset_path: ImageNet:split=TRAIN

--- a/dinov2/configs/ssl_default_config.yaml
+++ b/dinov2/configs/ssl_default_config.yaml
@@ -64,10 +64,15 @@ train:
   output_dir: .
   saveckp_freq: 20
   seed: 0
-  num_workers: 10
+  num_workers: 6
   OFFICIAL_EPOCH_LENGTH: 1250
-  cache_dataset: true
+  cache_dataset: false
   centering: "centering" # or "sinkhorn_knopp"
+  # DataLoader memory controls (tune per cluster)
+  pin_memory: true
+  prefetch_factor: 2
+  persistent_workers: true
+  shm_sharing_strategy: file_system  # or 'file_descriptor'
 student:
   arch: vit_large
   patch_size: 16

--- a/dinov2/configs/ssl_default_config.yaml
+++ b/dinov2/configs/ssl_default_config.yaml
@@ -93,12 +93,18 @@ train:
     chunks: {sample: 1024}
     to_chw: true
     normalize: true
+  # Performance features
+  torch_compile: false
+  torch_compile_mode: reduce-overhead  # reduce-overhead|max-autotune
+  channels_last: true  # 2D only; ignored in 3D
+  accumulate_steps: 1
 student:
   arch: vit_large
   patch_size: 16
   # set is_3d: true for 3D inputs (and then use tuple patch_size, e.g. [2,16,16])
   is_3d: false
   drop_path_rate: 0.3
+  activation_checkpointing: false
   layerscale: 1.0e-05
   drop_path_uniform: true
   pretrained_weights: ''

--- a/dinov2/data/augmentations.py
+++ b/dinov2/data/augmentations.py
@@ -6,6 +6,8 @@
 import logging
 
 from torchvision import transforms
+import torch
+import torch.nn.functional as F
 
 from .transforms import (
     GaussianBlur,
@@ -115,4 +117,158 @@ class DataAugmentationDINO(object):
         output["local_crops"] = local_crops
         output["offsets"] = ()
 
+        return output
+
+
+class RandomResizedCrop3D(object):
+    def __init__(self, output_size, scale=(0.32, 1.0)):
+        if isinstance(output_size, int):
+            output_size = (output_size, output_size, output_size)
+        self.out_d, self.out_h, self.out_w = output_size
+        self.scale = scale
+
+    def __call__(self, x):
+        # x: Tensor [C, D, H, W]
+        assert isinstance(x, torch.Tensor) and x.dim() == 4
+        _, D, H, W = x.shape
+        s = torch.empty(1).uniform_(self.scale[0], self.scale[1]).item()
+        # Use cubic root of scale to preserve volume fraction across dims
+        f = max(min(s ** (1.0 / 3.0), 1.0), 0.0)
+        cd = max(int(D * f), 1)
+        ch = max(int(H * f), 1)
+        cw = max(int(W * f), 1)
+        if cd > D: cd = D
+        if ch > H: ch = H
+        if cw > W: cw = W
+        sd = 0 if D == cd else torch.randint(0, D - cd + 1, (1,)).item()
+        sh = 0 if H == ch else torch.randint(0, H - ch + 1, (1,)).item()
+        sw = 0 if W == cw else torch.randint(0, W - cw + 1, (1,)).item()
+        x = x[:, sd:sd+cd, sh:sh+ch, sw:sw+cw]
+        x = x.unsqueeze(0)
+        x = F.interpolate(x, size=(self.out_d, self.out_h, self.out_w), mode="trilinear", align_corners=False)
+        x = x.squeeze(0)
+        return x
+
+
+class RandomFlip3D(object):
+    def __init__(self, p=0.5, dims=(3,)):
+        # dims in [2,3,4]: flipping axes for (D,H,W): depth=2,height=3,width=4 relative to [C,D,H,W]
+        self.p = p
+        self.dims = tuple(dims)
+
+    def __call__(self, x):
+        if torch.rand(()) < self.p:
+            for d in self.dims:
+                x = torch.flip(x, dims=(d,))
+        return x
+
+
+class GaussianBlur3D(object):
+    def __init__(self, sigma=1.0, p=1.0, kernel_size=5):
+        self.sigma = sigma
+        self.p = p
+        self.kernel_size = kernel_size
+
+    def __call__(self, x):
+        if torch.rand(()) >= self.p:
+            return x
+        # x: [C,D,H,W]
+        device = x.device
+        k = self.kernel_size
+        coords = torch.arange(k, dtype=torch.float32, device=device) - (k - 1) / 2.0
+        g = torch.exp(-(coords**2) / (2 * self.sigma**2))
+        g = g / g.sum()
+        g3 = (g[:, None, None] * g[None, :, None] * g[None, None, :]).unsqueeze(0).unsqueeze(0)  # [1,1,k,k,k]
+        weight = g3.repeat(x.shape[0], 1, 1, 1, 1)  # [C,1,k,k,k]
+        x = x.unsqueeze(0)
+        x = F.conv3d(x, weight, padding=k // 2, groups=weight.shape[0])
+        x = x.squeeze(0)
+        return x
+
+
+class IntensityJitter3D(object):
+    def __init__(self, brightness=0.4, contrast=0.4, p=0.8):
+        self.b = brightness
+        self.c = contrast
+        self.p = p
+
+    def __call__(self, x):
+        if torch.rand(()) >= self.p:
+            return x
+        # brightness
+        if self.b > 0:
+            delta = (torch.rand((), device=x.device) * 2 - 1) * self.b
+            x = x + delta
+        # contrast
+        if self.c > 0:
+            factor = 1.0 + (torch.rand((), device=x.device) * 2 - 1) * self.c
+            mean = x.mean(dim=(1, 2, 3), keepdim=True)
+            x = (x - mean) * factor + mean
+        return x
+
+
+class DataAugmentationDINO3D(object):
+    def __init__(
+        self,
+        global_crops_scale,
+        local_crops_scale,
+        local_crops_number,
+        global_crops_size=(32, 224, 224),
+        local_crops_size=(16, 96, 96),
+        flip_dims=(3,),
+    ):
+        self.global_crops_scale = global_crops_scale
+        self.local_crops_scale = local_crops_scale
+        self.local_crops_number = local_crops_number
+        if isinstance(global_crops_size, int):
+            global_crops_size = (global_crops_size, global_crops_size, global_crops_size)
+        if isinstance(local_crops_size, int):
+            local_crops_size = (local_crops_size, local_crops_size, local_crops_size)
+        self.global_crops_size = global_crops_size
+        self.local_crops_size = local_crops_size
+
+        logger.info("###################################")
+        logger.info("Using 3D data augmentation parameters:")
+        logger.info(f"global_crops_scale: {global_crops_scale}")
+        logger.info(f"local_crops_scale: {local_crops_scale}")
+        logger.info(f"local_crops_number: {local_crops_number}")
+        logger.info(f"global_crops_size: {global_crops_size}")
+        logger.info(f"local_crops_size: {local_crops_size}")
+        logger.info("###################################")
+
+        self.geometric_augmentation_global = transforms.Compose(
+            [RandomResizedCrop3D(global_crops_size, scale=global_crops_scale), RandomFlip3D(p=0.5, dims=flip_dims)]
+        )
+        self.geometric_augmentation_local = transforms.Compose(
+            [RandomResizedCrop3D(local_crops_size, scale=local_crops_scale), RandomFlip3D(p=0.5, dims=flip_dims)]
+        )
+
+        intensity_jitter = IntensityJitter3D(brightness=0.4, contrast=0.4, p=0.8)
+        global_transfo1_extra = GaussianBlur3D(p=1.0, sigma=1.0)
+        global_transfo2_extra = transforms.Compose([GaussianBlur3D(p=0.1, sigma=1.0)])
+        local_transfo_extra = GaussianBlur3D(p=0.5, sigma=1.0)
+
+        def _normalize(x):
+            # Expect input float in [0,1]; clip for safety
+            return x.clamp(0.0, 1.0)
+
+        self.normalize = _normalize
+        self.global_transfo1 = transforms.Compose([intensity_jitter, global_transfo1_extra, self.normalize])
+        self.global_transfo2 = transforms.Compose([intensity_jitter, global_transfo2_extra, self.normalize])
+        self.local_transfo = transforms.Compose([intensity_jitter, local_transfo_extra, self.normalize])
+
+    def __call__(self, volume_tensor):
+        # volume_tensor: Tensor [C, D, H, W], values expected in [0,1]
+        output = {}
+
+        vol1_base = self.geometric_augmentation_global(volume_tensor)
+        global_crop_1 = self.global_transfo1(vol1_base)
+        vol2_base = self.geometric_augmentation_global(volume_tensor)
+        global_crop_2 = self.global_transfo2(vol2_base)
+        output["global_crops"] = [global_crop_1, global_crop_2]
+        output["global_crops_teacher"] = [global_crop_1, global_crop_2]
+
+        local_crops = [self.local_transfo(self.geometric_augmentation_local(volume_tensor)) for _ in range(self.local_crops_number)]
+        output["local_crops"] = local_crops
+        output["offsets"] = ()
         return output

--- a/dinov2/data/collate.py
+++ b/dinov2/data/collate.py
@@ -4,6 +4,7 @@
 # found in the LICENSE file in the root directory of this source tree.
 
 import torch
+import math
 import random
 
 
@@ -34,7 +35,23 @@ def collate_data_and_cast(samples_list, mask_ratio_tuple, mask_probability, dtyp
     random.shuffle(masks_list)
 
     collated_masks = torch.stack(masks_list).flatten(1)
-    mask_indices_list = collated_masks.flatten().nonzero().flatten()
+
+    # Build data-missing mask at token level from NaNs in inputs (global crops only)
+    # Detect missing pixels across channels, then aggregate per patch token
+    C, H, W = collated_global_crops.shape[1:]
+    M = int(math.sqrt(N)) if N is not None else None
+    if N is not None and M * M == N and H % M == 0 and W % M == 0:
+        missing_pixels = torch.isnan(collated_global_crops).any(dim=1)  # [B,H,W]
+        ph, pw = H // M, W // M
+        missing_tokens = (
+            missing_pixels.view(B, M, ph, M, pw).any(-1).any(-2).view(B, N)
+        )  # [B,N]
+    else:
+        missing_tokens = torch.zeros((B, N), dtype=torch.bool, device=collated_global_crops.device)
+
+    # Exclude missing tokens from iBOT masked indices
+    effective_ibot_masks = collated_masks & (~missing_tokens)
+    mask_indices_list = effective_ibot_masks.flatten().nonzero().flatten()
 
     masks_weight = (1 / collated_masks.sum(-1).clamp(min=1.0)).unsqueeze(-1).expand_as(collated_masks)[collated_masks]
 
@@ -42,6 +59,7 @@ def collate_data_and_cast(samples_list, mask_ratio_tuple, mask_probability, dtyp
         "collated_global_crops": collated_global_crops.to(dtype),
         "collated_local_crops": collated_local_crops.to(dtype),
         "collated_masks": collated_masks,
+        "data_missing_tokens": missing_tokens,
         "mask_indices_list": mask_indices_list,
         "masks_weight": masks_weight,
         "upperbound": upperbound,

--- a/dinov2/data/loaders.py
+++ b/dinov2/data/loaders.py
@@ -5,10 +5,10 @@
 
 import logging
 from enum import Enum
-from typing import Any, Callable, List, Optional, TypeVar
+from typing import Any, Callable, List, Optional, TypeVar, Tuple, Union, Iterable
 
 import torch
-from torch.utils.data import Sampler
+from torch.utils.data import Sampler, IterableDataset, get_worker_info
 
 from .datasets import ImageNet, ImageNet22k
 
@@ -230,6 +230,137 @@ def make_data_loader(
     except TypeError:  # data loader has no length
         logger.info("infinite data loader")
     return data_loader
+
+
+# ---------------------- Optional tiling for large inputs ----------------------
+try:
+    from torchvision.transforms.functional import crop as tv_crop
+except Exception:
+    tv_crop = None  # type: ignore
+
+
+def _compute_starts(size: int, tile: int, stride: int, drop_last: bool) -> List[int]:
+    if tile >= size:
+        return [0]
+    starts = list(range(0, size - tile + 1, stride))
+    if not drop_last:
+        last_start = size - tile
+        if starts[-1] != last_start:
+            starts.append(last_start)
+    return starts
+
+
+def _iter_tiles_2d(img, tile_hw: Tuple[int, int], stride_hw: Tuple[int, int], drop_last: bool):
+    # img can be PIL Image or Tensor [C,H,W]
+    if torch.is_tensor(img):
+        _, H, W = img.shape
+    else:
+        W, H = img.size  # PIL
+    th, tw = tile_hw
+    sh, sw = stride_hw
+    hs = _compute_starts(H, th, sh, drop_last)
+    ws = _compute_starts(W, tw, sw, drop_last)
+    for top in hs:
+        for left in ws:
+            if torch.is_tensor(img):
+                yield img[:, top : top + th, left : left + tw], (top, left)
+            else:
+                assert tv_crop is not None, "torchvision is required for 2D PIL tiling"
+                tile = tv_crop(img, top, left, th, tw)
+                yield tile, (top, left)
+
+
+def _iter_tiles_3d(vol: torch.Tensor, tile_dhw: Tuple[int, int, int], stride_dhw: Tuple[int, int, int], drop_last: bool):
+    # vol: Tensor [C,D,H,W]
+    _, D, H, W = vol.shape
+    td, th, tw = tile_dhw
+    sd, sh, sw = stride_dhw
+    ds = _compute_starts(D, td, sd, drop_last)
+    hs = _compute_starts(H, th, sh, drop_last)
+    ws = _compute_starts(W, tw, sw, drop_last)
+    for z in ds:
+        for y in hs:
+            for x in ws:
+                yield vol[:, z : z + td, y : y + th, x : x + tw], (z, y, x)
+
+
+class TiledIterableDataset(IterableDataset):
+    def __init__(
+        self,
+        base_dataset,
+        *,
+        is_3d: bool,
+        tile_size: Union[Tuple[int, int], Tuple[int, int, int]],
+        stride: Union[Tuple[int, int], Tuple[int, int, int]],
+        drop_last_tiles: bool = True,
+        transform=None,
+    ):
+        super().__init__()
+        self.base_dataset = base_dataset
+        self.is_3d = is_3d
+        self.tile_size = tile_size
+        self.stride = stride
+        self.drop_last_tiles = drop_last_tiles
+        self.transform = transform
+
+    def _sharded_indices(self) -> Iterable[int]:
+        # Shard base sample indices across distributed processes and dataloader workers
+        world_size = distributed.get_global_size()
+        global_rank = distributed.get_global_rank()
+
+        worker = get_worker_info()
+        if worker is None:
+            worker_id = 0
+            num_workers = 1
+        else:
+            worker_id = worker.id
+            num_workers = worker.num_workers
+
+        step = max(1, world_size * num_workers)
+        offset = global_rank * num_workers + worker_id
+        for idx in range(offset, len(self.base_dataset), step):
+            yield idx
+
+    def __iter__(self):
+        for idx in self._sharded_indices():
+            sample = self.base_dataset[idx]
+            if isinstance(sample, tuple):
+                img, target = sample
+            else:
+                img, target = sample, None
+
+            if self.is_3d:
+                assert torch.is_tensor(img) and img.dim() == 4, "3D tiling expects Tensor [C,D,H,W]"
+                for tile, offs in _iter_tiles_3d(img, self.tile_size, self.stride, self.drop_last_tiles):
+                    out = self.transform(tile) if self.transform is not None else tile
+                    if isinstance(out, dict):
+                        out["tile_origin"] = offs
+                    yield (out, target)
+            else:
+                for tile, offs in _iter_tiles_2d(img, self.tile_size, self.stride, self.drop_last_tiles):
+                    out = self.transform(tile) if self.transform is not None else tile
+                    if isinstance(out, dict):
+                        out["tile_origin"] = offs
+                    yield (out, target)
+
+
+def make_tiled_iterable_dataset(
+    *,
+    dataset,
+    is_3d: bool,
+    tile_size: Union[Tuple[int, int], Tuple[int, int, int]],
+    stride: Union[Tuple[int, int], Tuple[int, int, int]],
+    drop_last_tiles: bool,
+    transform=None,
+):
+    return TiledIterableDataset(
+        dataset,
+        is_3d=is_3d,
+        tile_size=tuple(tile_size),
+        stride=tuple(stride),
+        drop_last_tiles=drop_last_tiles,
+        transform=transform,
+    )
 
 
 def make_xarray_loader(

--- a/dinov2/data/loaders.py
+++ b/dinov2/data/loaders.py
@@ -176,6 +176,8 @@ def make_data_loader(
     drop_last: bool = True,
     persistent_workers: bool = False,
     collate_fn: Optional[Callable[[List[T]], Any]] = None,
+    pin_memory: bool = True,
+    prefetch_factor: int = 2,
 ):
     """
     Creates a data loader with the specified parameters.
@@ -209,7 +211,8 @@ def make_data_loader(
         sampler=sampler,
         batch_size=batch_size,
         num_workers=num_workers,
-        pin_memory=True,
+        pin_memory=pin_memory,
+        prefetch_factor=prefetch_factor if num_workers > 0 else None,
         drop_last=drop_last,
         persistent_workers=persistent_workers,
         collate_fn=collate_fn,

--- a/dinov2/data/loaders.py
+++ b/dinov2/data/loaders.py
@@ -11,6 +11,13 @@ import torch
 from torch.utils.data import Sampler
 
 from .datasets import ImageNet, ImageNet22k
+
+try:
+    import xarray as xr  # type: ignore
+    from xbatcher import BatchGenerator  # type: ignore
+    _XR_AVAILABLE = True
+except Exception:
+    _XR_AVAILABLE = False
 from .samplers import EpochSampler, InfiniteSampler, ShardedInfiniteSampler
 
 
@@ -223,3 +230,51 @@ def make_data_loader(
     except TypeError:  # data loader has no length
         logger.info("infinite data loader")
     return data_loader
+
+
+def make_xarray_loader(
+    *,
+    ds_path: str,
+    image_var: str,
+    target_var: Optional[str] = None,
+    batch_size: int,
+    num_workers: int = 0,
+    to_chw: bool = True,
+    normalize: bool = True,
+    chunks: Optional[dict] = None,
+):
+    if not _XR_AVAILABLE:
+        raise RuntimeError("xarray/xbatcher not available; please install xarray and xbatcher.")
+
+    ds = xr.open_zarr(ds_path) if ds_path.endswith(".zarr") else xr.open_dataset(ds_path)
+    if chunks:
+        ds = ds.chunk(chunks)
+
+    img = ds[image_var]
+    tgt = ds[target_var] if target_var and target_var in ds else None
+
+    # Expect a leading sample dimension; name may vary
+    sample_dim = img.dims[0]
+    bg = BatchGenerator(ds, input_dims={image_var: {sample_dim: batch_size}}, shuffle=True)
+
+    def _to_tensor(npx):
+        import numpy as np
+        import torch
+
+        arr = npx.values  # NumPy array
+        if to_chw and arr.shape[-1] in (1, 3):
+            arr = arr.transpose(0, 3, 1, 2)
+        t = torch.from_numpy(arr).float()
+        if normalize:
+            t = t / 255.0
+        return t
+
+    def _iter():
+        for batch in bg:
+            images = _to_tensor(batch[image_var])
+            targets = None
+            if tgt is not None:
+                targets = torch.from_numpy(batch[target_var].values)
+            yield [(dict(global_crops=[img for img in images[:2]], local_crops=list(images[2:])), targets)]
+
+    return _iter()

--- a/dinov2/data/loaders.py
+++ b/dinov2/data/loaders.py
@@ -373,6 +373,7 @@ def make_xarray_loader(
     to_chw: bool = True,
     normalize: bool = True,
     chunks: Optional[dict] = None,
+    tiling: Optional[dict] = None,
 ):
     if not _XR_AVAILABLE:
         raise RuntimeError("xarray/xbatcher not available; please install xarray and xbatcher.")
@@ -386,7 +387,37 @@ def make_xarray_loader(
 
     # Expect a leading sample dimension; name may vary
     sample_dim = img.dims[0]
-    bg = BatchGenerator(ds, input_dims={image_var: {sample_dim: batch_size}}, shuffle=True)
+    if tiling and tiling.get("enabled", False):
+        # Determine spatial dims for tiling
+        is_3d = bool(tiling.get("is_3d", False))
+        tile_size = tuple(tiling.get("tile_size"))
+        stride = tuple(tiling.get("stride"))
+
+        # Build dimension dict for xbatcher: batch over samples and window over spatial dims
+        if is_3d:
+            # assume dims: (sample, D, H, W, C) or (sample, C, D, H, W)
+            spatial_dims = [d for d in img.dims if d not in (sample_dim,)]
+            # pick last 3 as D,H,W
+            dhw = spatial_dims[-3:]
+            input_dims = {
+                image_var: {
+                    sample_dim: batch_size,
+                    dhw[0]: tile_size[0],
+                    dhw[1]: tile_size[1],
+                    dhw[2]: tile_size[2],
+                }
+            }
+            bg = BatchGenerator(ds, input_dims=input_dims, steps={dhw[0]: stride[0], dhw[1]: stride[1], dhw[2]: stride[2]}, shuffle=True)
+        else:
+            # 2D: pick last 2 spatial dims as H,W
+            spatial_dims = [d for d in img.dims if d not in (sample_dim,)]
+            hw = spatial_dims[-2:]
+            input_dims = {
+                image_var: {sample_dim: batch_size, hw[0]: tile_size[0], hw[1]: tile_size[1]}
+            }
+            bg = BatchGenerator(ds, input_dims=input_dims, steps={hw[0]: stride[0], hw[1]: stride[1]}, shuffle=True)
+    else:
+        bg = BatchGenerator(ds, input_dims={image_var: {sample_dim: batch_size}}, shuffle=True)
 
     def _to_tensor(npx):
         import numpy as np

--- a/dinov2/layers/__init__.py
+++ b/dinov2/layers/__init__.py
@@ -10,3 +10,4 @@ from .patch_embed import PatchEmbed
 from .swiglu_ffn import SwiGLUFFN, SwiGLUFFNFused, SwiGLUFFNAligned
 from .block import NestedTensorBlock, CausalAttentionBlock
 from .attention import Attention, MemEffAttention
+from .lora import apply_lora_to_vit

--- a/dinov2/layers/lora.py
+++ b/dinov2/layers/lora.py
@@ -1,0 +1,89 @@
+import math
+from typing import Iterable, Optional, Sequence
+
+import torch
+from torch import nn, Tensor
+
+
+class LoRALinear(nn.Module):
+    def __init__(
+        self,
+        base: nn.Linear,
+        r: int = 8,
+        lora_alpha: float = 16.0,
+        lora_dropout: float = 0.0,
+    ) -> None:
+        super().__init__()
+        self.in_features = base.in_features
+        self.out_features = base.out_features
+        self.r = int(r)
+        self.lora_alpha = float(lora_alpha)
+        self.scaling = (self.lora_alpha / self.r) if self.r > 0 else 1.0
+        self.lora_dropout = nn.Dropout(lora_dropout) if lora_dropout > 0 else nn.Identity()
+
+        # Base linear params (frozen)
+        self.weight = nn.Parameter(base.weight.detach().clone())
+        self.weight.requires_grad_(False)
+        if base.bias is not None:
+            self.bias = nn.Parameter(base.bias.detach().clone())
+            self.bias.requires_grad_(False)
+        else:
+            self.bias = None
+
+        # LoRA params
+        if self.r > 0:
+            self.lora_A = nn.Parameter(torch.empty(self.r, self.in_features))
+            self.lora_B = nn.Parameter(torch.empty(self.out_features, self.r))
+            self.reset_lora_parameters()
+        else:
+            self.register_parameter("lora_A", None)
+            self.register_parameter("lora_B", None)
+
+    def reset_lora_parameters(self) -> None:
+        if self.lora_A is not None:
+            nn.init.kaiming_uniform_(self.lora_A, a=math.sqrt(5))
+        if self.lora_B is not None:
+            nn.init.zeros_(self.lora_B)
+
+    def forward(self, x: Tensor) -> Tensor:
+        result = nn.functional.linear(x, self.weight, self.bias)
+        if self.r > 0 and self.lora_A is not None and self.lora_B is not None:
+            lora_out = nn.functional.linear(self.lora_dropout(x), self.lora_A.T)
+            lora_out = nn.functional.linear(lora_out, self.lora_B.T)
+            result = result + self.scaling * lora_out
+        return result
+
+
+def _replace_child(module: nn.Module, child_name: str, new_child: nn.Module) -> None:
+    parts = child_name.split(".")
+    parent = module
+    for p in parts[:-1]:
+        parent = getattr(parent, p)
+    setattr(parent, parts[-1], new_child)
+
+
+def apply_lora_to_vit(
+    model: nn.Module,
+    *,
+    target_substrings: Sequence[str] = ("qkv", "proj", "fc1", "fc2"),
+    r: int = 8,
+    alpha: float = 16.0,
+    dropout: float = 0.0,
+) -> nn.Module:
+    """
+    Wrap selected Linear layers with LoRA adapters.
+    target_substrings selects modules by name suffix (e.g., 'qkv','proj','fc1','fc2').
+    """
+    named_modules = dict(model.named_modules())
+    # Collect linear module names to avoid modifying while iterating
+    linear_names = []
+    for name, mod in named_modules.items():
+        if isinstance(mod, nn.Linear) and any(name.endswith(t) for t in target_substrings):
+            linear_names.append(name)
+
+    for name in linear_names:
+        base = named_modules[name]
+        lora = LoRALinear(base, r=r, lora_alpha=alpha, lora_dropout=dropout)
+        _replace_child(model, name, lora)
+
+    return model

--- a/dinov2/layers/patch_embed.py
+++ b/dinov2/layers/patch_embed.py
@@ -22,6 +22,14 @@ def make_2tuple(x):
     return (x, x)
 
 
+def make_3tuple(x):
+    if isinstance(x, tuple):
+        assert len(x) == 3
+        return x
+    assert isinstance(x, int)
+    return (x, x, x)
+
+
 class PatchEmbed(nn.Module):
     """
     2D image to patch embedding: (B,C,H,W) -> (B,N,D)
@@ -85,4 +93,74 @@ class PatchEmbed(nn.Module):
         flops = Ho * Wo * self.embed_dim * self.in_chans * (self.patch_size[0] * self.patch_size[1])
         if self.norm is not None:
             flops += Ho * Wo * self.embed_dim
+        return flops
+
+
+class PatchEmbed3D(nn.Module):
+    """
+    3D volume to patch embedding: (B,C,D,H,W) -> (B,N,D)
+
+    Args:
+        img_size: Volume size.
+        patch_size: Patch token size (Dz, Dy, Dx).
+        in_chans: Number of input channels.
+        embed_dim: Number of linear projection output channels.
+        norm_layer: Normalization layer.
+    """
+
+    def __init__(
+        self,
+        img_size: Union[int, Tuple[int, int, int]] = 32,
+        patch_size: Union[int, Tuple[int, int, int]] = 4,
+        in_chans: int = 1,
+        embed_dim: int = 768,
+        norm_layer: Optional[Callable] = None,
+        flatten_embedding: bool = True,
+    ) -> None:
+        super().__init__()
+
+        image_DHW = make_3tuple(img_size)
+        patch_DHW = make_3tuple(patch_size)
+        patch_grid_size = (
+            image_DHW[0] // patch_DHW[0],
+            image_DHW[1] // patch_DHW[1],
+            image_DHW[2] // patch_DHW[2],
+        )
+
+        self.img_size = image_DHW
+        self.patch_size = patch_DHW
+        self.patches_resolution = patch_grid_size
+        self.num_patches = patch_grid_size[0] * patch_grid_size[1] * patch_grid_size[2]
+
+        self.in_chans = in_chans
+        self.embed_dim = embed_dim
+
+        self.flatten_embedding = flatten_embedding
+
+        self.proj = nn.Conv3d(in_chans, embed_dim, kernel_size=patch_DHW, stride=patch_DHW)
+        self.norm = norm_layer(embed_dim) if norm_layer else nn.Identity()
+
+    def forward(self, x: Tensor) -> Tensor:
+        _, _, D, H, W = x.shape
+        patch_D, patch_H, patch_W = self.patch_size
+
+        assert D % patch_D == 0, f"Input depth {D} is not a multiple of patch depth {patch_D}"
+        assert H % patch_H == 0, f"Input height {H} is not a multiple of patch height {patch_H}"
+        assert W % patch_W == 0, f"Input width {W} is not a multiple of patch width {patch_W}"
+
+        x = self.proj(x)  # B C D H W
+        D, H, W = x.size(2), x.size(3), x.size(4)
+        x = x.flatten(2).transpose(1, 2)  # B DHW C
+        x = self.norm(x)
+        if not self.flatten_embedding:
+            x = x.reshape(-1, D, H, W, self.embed_dim)  # B D H W C
+        return x
+
+    def flops(self) -> float:
+        Do, Ho, Wo = self.patches_resolution
+        flops = Do * Ho * Wo * self.embed_dim * self.in_chans * (
+            self.patch_size[0] * self.patch_size[1] * self.patch_size[2]
+        )
+        if self.norm is not None:
+            flops += Do * Ho * Wo * self.embed_dim
         return flops

--- a/dinov2/models/__init__.py
+++ b/dinov2/models/__init__.py
@@ -27,6 +27,10 @@ def build_model(args, only_teacher=False, img_size=224):
             interpolate_offset=args.interpolate_offset,
             interpolate_antialias=args.interpolate_antialias,
         )
+        # Optional 3D input support
+        is_3d = getattr(args, "is_3d", False)
+        if is_3d:
+            vit_kwargs["is_3d"] = True
         # Optional model-parallel devices specified in config as a list
         mp_devices = getattr(args, "mp_devices", None)
         if mp_devices:

--- a/dinov2/models/__init__.py
+++ b/dinov2/models/__init__.py
@@ -27,6 +27,10 @@ def build_model(args, only_teacher=False, img_size=224):
             interpolate_offset=args.interpolate_offset,
             interpolate_antialias=args.interpolate_antialias,
         )
+        # Optional model-parallel devices specified in config as a list
+        mp_devices = getattr(args, "mp_devices", None)
+        if mp_devices:
+            vit_kwargs["mp_devices"] = mp_devices
         teacher = vits.__dict__[args.arch](**vit_kwargs)
         if only_teacher:
             return teacher, teacher.embed_dim

--- a/dinov2/models/vision_transformer.py
+++ b/dinov2/models/vision_transformer.py
@@ -66,6 +66,7 @@ class DinoVisionTransformer(nn.Module):
         num_register_tokens=0,
         interpolate_antialias=False,
         interpolate_offset=0.1,
+        mp_devices: Union[Sequence[Union[int, str, torch.device]], None] = None,
     ):
         """
         Args:
@@ -170,6 +171,99 @@ class DinoVisionTransformer(nn.Module):
 
         self.init_weights()
 
+        # Optional model-parallel setup across multiple CUDA devices
+        self.model_parallel = False
+        if mp_devices:
+            self._setup_model_parallel(mp_devices)
+
+    # -------------------- Model Parallel Helpers --------------------
+    def _normalize_devices(self, mp_devices: Sequence[Union[int, str, torch.device]]):
+        devices: list[torch.device] = []
+        for d in mp_devices:
+            if isinstance(d, torch.device):
+                devices.append(d)
+            elif isinstance(d, int):
+                devices.append(torch.device(f"cuda:{d}"))
+            elif isinstance(d, str):
+                # allow forms like "cuda", "cuda:0"
+                if d == "cuda":
+                    devices.append(torch.device("cuda:0"))
+                else:
+                    devices.append(torch.device(d))
+            else:
+                raise ValueError(f"Unsupported device spec: {d}")
+        if not devices:
+            raise ValueError("mp_devices must contain at least one device")
+        return devices
+
+    def _compute_stage_splits(self, total: int, stages: int):
+        # Return list of (start, end) indices partitioning [0, total)
+        base = total // stages
+        rem = total % stages
+        splits = []
+        start = 0
+        for i in range(stages):
+            length = base + (1 if i < rem else 0)
+            end = start + length
+            splits.append((start, end))
+            start = end
+        return splits
+
+    def _iter_all_block_modules(self):
+        if self.chunked_blocks:
+            for chunk in self.blocks:
+                # BlockChunk is a ModuleList
+                for sub in chunk:
+                    if isinstance(sub, nn.Identity):
+                        continue
+                    yield sub
+        else:
+            for blk in self.blocks:
+                yield blk
+
+    def _setup_model_parallel(self, mp_devices: Sequence[Union[int, str, torch.device]]):
+        if not torch.cuda.is_available():
+            logger.warning("Model parallel requested but CUDA is not available. Ignoring.")
+            return
+        devices = self._normalize_devices(mp_devices)
+        if len(devices) == 1:
+            # nothing to do
+            return
+        if self.chunked_blocks:
+            # We could support this by moving sub-blocks individually, but it's error-prone.
+            raise NotImplementedError("Model parallel is not supported when block_chunks > 0")
+
+        self.mp_devices: list[torch.device] = devices
+        self.stage_splits = self._compute_stage_splits(self.n_blocks, len(devices))
+
+        # Build a per-block device map
+        block_devices: list[torch.device] = [devices[0]] * self.n_blocks
+        for stage_idx, (s, e) in enumerate(self.stage_splits):
+            for i in range(s, e):
+                block_devices[i] = devices[stage_idx]
+        self._block_devices = block_devices
+
+        # Move embedding and tokens to first device
+        first_device = devices[0]
+        self.patch_embed.to(first_device)
+        self.cls_token = nn.Parameter(self.cls_token.to(first_device))
+        self.pos_embed = nn.Parameter(self.pos_embed.to(first_device))
+        if self.register_tokens is not None:
+            self.register_tokens = nn.Parameter(self.register_tokens.to(first_device))
+        self.mask_token = nn.Parameter(self.mask_token.to(first_device))
+
+        # Move transformer blocks to their target devices
+        for i, blk in enumerate(self._iter_all_block_modules()):
+            target = block_devices[i]
+            blk.to(target)
+
+        # Move norm and head to the last device
+        last_device = devices[-1]
+        self.norm.to(last_device)
+        self.head.to(last_device)
+
+        self.model_parallel = True
+
     def init_weights(self):
         trunc_normal_(self.pos_embed, std=0.02)
         nn.init.normal_(self.cls_token, std=1e-6)
@@ -215,6 +309,9 @@ class DinoVisionTransformer(nn.Module):
         B, nc, w, h = x.shape
         x = self.patch_embed(x)
         if masks is not None:
+            # Ensure masks live on same device as activations
+            if masks.device != x.device:
+                masks = masks.to(x.device, non_blocking=True)
             x = torch.where(masks.unsqueeze(-1), self.mask_token.to(x.dtype).unsqueeze(0), x)
 
         x = torch.cat((self.cls_token.expand(x.shape[0], -1, -1), x), dim=1)
@@ -233,9 +330,20 @@ class DinoVisionTransformer(nn.Module):
         return x
 
     def forward_features_list(self, x_list, masks_list):
-        x = [self.prepare_tokens_with_masks(x, masks) for x, masks in zip(x_list, masks_list)]
-        for blk in self.blocks:
-            x = blk(x)
+        if not self.model_parallel:
+            x = [self.prepare_tokens_with_masks(x, masks) for x, masks in zip(x_list, masks_list)]
+            for blk in self.blocks:
+                x = blk(x)
+        else:
+            # Place inputs on first device
+            first_device = self.mp_devices[0]
+            x = [xi.to(first_device, non_blocking=True) for xi in x_list]
+            x = [self.prepare_tokens_with_masks(xi, mi) for xi, mi in zip(x, masks_list)]
+            # Iterate actual blocks and move lists across devices as needed
+            for i, blk in enumerate(self._iter_all_block_modules()):
+                target = self._block_devices[i]
+                x = [xi.to(target, non_blocking=True) for xi in x]
+                x = blk(x)
 
         all_x = x
         output = []
@@ -256,10 +364,20 @@ class DinoVisionTransformer(nn.Module):
         if isinstance(x, list):
             return self.forward_features_list(x, masks)
 
-        x = self.prepare_tokens_with_masks(x, masks)
-
-        for blk in self.blocks:
-            x = blk(x)
+        if not self.model_parallel:
+            x = self.prepare_tokens_with_masks(x, masks)
+            for blk in self.blocks:
+                x = blk(x)
+        else:
+            # Move input to first stage device
+            first_device = self.mp_devices[0]
+            x = x.to(first_device, non_blocking=True)
+            x = self.prepare_tokens_with_masks(x, masks)
+            for i, blk in enumerate(self._iter_all_block_modules()):
+                target = self._block_devices[i]
+                if x.device != target:
+                    x = x.to(target, non_blocking=True)
+                x = blk(x)
 
         x_norm = self.norm(x)
         return {

--- a/dinov2/models/vision_transformer.py
+++ b/dinov2/models/vision_transformer.py
@@ -10,7 +10,7 @@
 from functools import partial
 import math
 import logging
-from typing import Sequence, Tuple, Union, Callable
+from typing import Sequence, Tuple, Union, Callable, List
 
 import numpy as np
 import torch
@@ -178,7 +178,7 @@ class DinoVisionTransformer(nn.Module):
 
     # -------------------- Model Parallel Helpers --------------------
     def _normalize_devices(self, mp_devices: Sequence[Union[int, str, torch.device]]):
-        devices: list[torch.device] = []
+        devices: List[torch.device] = []
         for d in mp_devices:
             if isinstance(d, torch.device):
                 devices.append(d)
@@ -233,11 +233,11 @@ class DinoVisionTransformer(nn.Module):
             # We could support this by moving sub-blocks individually, but it's error-prone.
             raise NotImplementedError("Model parallel is not supported when block_chunks > 0")
 
-        self.mp_devices: list[torch.device] = devices
+        self.mp_devices: List[torch.device] = devices
         self.stage_splits = self._compute_stage_splits(self.n_blocks, len(devices))
 
         # Build a per-block device map
-        block_devices: list[torch.device] = [devices[0]] * self.n_blocks
+        block_devices: List[torch.device] = [devices[0]] * self.n_blocks
         for stage_idx, (s, e) in enumerate(self.stage_splits):
             for i in range(s, e):
                 block_devices[i] = devices[stage_idx]

--- a/dinov2/models/vision_transformer.py
+++ b/dinov2/models/vision_transformer.py
@@ -18,7 +18,7 @@ import torch.nn as nn
 import torch.utils.checkpoint
 from torch.nn.init import trunc_normal_
 
-from dinov2.layers import Mlp, PatchEmbed, SwiGLUFFNFused, MemEffAttention, NestedTensorBlock as Block
+from dinov2.layers import Mlp, PatchEmbed, PatchEmbed3D, SwiGLUFFNFused, MemEffAttention, NestedTensorBlock as Block
 
 
 logger = logging.getLogger("dinov2")
@@ -66,6 +66,7 @@ class DinoVisionTransformer(nn.Module):
         num_register_tokens=0,
         interpolate_antialias=False,
         interpolate_offset=0.1,
+        is_3d: bool = False,
         mp_devices: Union[Sequence[Union[int, str, torch.device]], None] = None,
     ):
         """
@@ -101,11 +102,19 @@ class DinoVisionTransformer(nn.Module):
         self.n_blocks = depth
         self.num_heads = num_heads
         self.patch_size = patch_size
+        self.is_3d = is_3d
         self.num_register_tokens = num_register_tokens
         self.interpolate_antialias = interpolate_antialias
         self.interpolate_offset = interpolate_offset
 
-        self.patch_embed = embed_layer(img_size=img_size, patch_size=patch_size, in_chans=in_chans, embed_dim=embed_dim)
+        if is_3d:
+            self.patch_embed = PatchEmbed3D(
+                img_size=img_size, patch_size=patch_size, in_chans=in_chans, embed_dim=embed_dim
+            )
+        else:
+            self.patch_embed = embed_layer(
+                img_size=img_size, patch_size=patch_size, in_chans=in_chans, embed_dim=embed_dim
+            )
         num_patches = self.patch_embed.num_patches
 
         self.cls_token = nn.Parameter(torch.zeros(1, 1, embed_dim))
@@ -271,42 +280,79 @@ class DinoVisionTransformer(nn.Module):
             nn.init.normal_(self.register_tokens, std=1e-6)
         named_apply(init_weights_vit_timm, self)
 
-    def interpolate_pos_encoding(self, x, w, h):
+    def interpolate_pos_encoding(self, x, w, h, d=None):
         previous_dtype = x.dtype
         npatch = x.shape[1] - 1
         N = self.pos_embed.shape[1] - 1
-        if npatch == N and w == h:
+        if not self.is_3d and npatch == N and w == h:
             return self.pos_embed
         pos_embed = self.pos_embed.float()
         class_pos_embed = pos_embed[:, 0]
         patch_pos_embed = pos_embed[:, 1:]
         dim = x.shape[-1]
-        w0 = w // self.patch_size
-        h0 = h // self.patch_size
-        M = int(math.sqrt(N))  # Recover the number of patches in each dimension
-        assert N == M * M
+        if self.is_3d:
+            assert d is not None, "depth must be provided for 3D positional encoding"
+            # patch_size may be a tuple (Dz, Dy, Dx)
+            if isinstance(self.patch_size, tuple):
+                pd, ph, pw = self.patch_size
+            else:
+                pd = ph = pw = self.patch_size
+            w0 = w // pw
+            h0 = h // ph
+            d0 = d // pd
+            M = round(N ** (1 / 3))
+            assert N == M * M * M
+        else:
+            w0 = w // self.patch_size
+            h0 = h // self.patch_size
+            M = int(math.sqrt(N))  # Recover the number of patches in each dimension
+            assert N == M * M
         kwargs = {}
         if self.interpolate_offset:
             # Historical kludge: add a small number to avoid floating point error in the interpolation, see https://github.com/facebookresearch/dino/issues/8
             # Note: still needed for backward-compatibility, the underlying operators are using both output size and scale factors
-            sx = float(w0 + self.interpolate_offset) / M
-            sy = float(h0 + self.interpolate_offset) / M
-            kwargs["scale_factor"] = (sx, sy)
+            if self.is_3d:
+                sx = float(w0 + self.interpolate_offset) / M
+                sy = float(h0 + self.interpolate_offset) / M
+                sz = float(d0 + self.interpolate_offset) / M
+                kwargs["scale_factor"] = (sx, sy, sz)
+            else:
+                sx = float(w0 + self.interpolate_offset) / M
+                sy = float(h0 + self.interpolate_offset) / M
+                kwargs["scale_factor"] = (sx, sy)
         else:
             # Simply specify an output size instead of a scale factor
-            kwargs["size"] = (w0, h0)
-        patch_pos_embed = nn.functional.interpolate(
-            patch_pos_embed.reshape(1, M, M, dim).permute(0, 3, 1, 2),
-            mode="bicubic",
-            antialias=self.interpolate_antialias,
-            **kwargs,
-        )
-        assert (w0, h0) == patch_pos_embed.shape[-2:]
-        patch_pos_embed = patch_pos_embed.permute(0, 2, 3, 1).view(1, -1, dim)
+            if self.is_3d:
+                kwargs["size"] = (d0, w0, h0)
+            else:
+                kwargs["size"] = (w0, h0)
+        if self.is_3d:
+            # reshape to (1, C, D, H, W)
+            patch_pos_embed = patch_pos_embed.reshape(1, M, M, M, dim).permute(0, 4, 1, 2, 3)
+            patch_pos_embed = nn.functional.interpolate(
+                patch_pos_embed,
+                mode="trilinear",
+                antialias=self.interpolate_antialias,
+                **kwargs,
+            )
+            assert (d0, w0, h0) == patch_pos_embed.shape[-3:]
+            patch_pos_embed = patch_pos_embed.permute(0, 2, 3, 4, 1).contiguous().view(1, -1, dim)
+        else:
+            patch_pos_embed = nn.functional.interpolate(
+                patch_pos_embed.reshape(1, M, M, dim).permute(0, 3, 1, 2),
+                mode="bicubic",
+                antialias=self.interpolate_antialias,
+                **kwargs,
+            )
+            assert (w0, h0) == patch_pos_embed.shape[-2:]
+            patch_pos_embed = patch_pos_embed.permute(0, 2, 3, 1).view(1, -1, dim)
         return torch.cat((class_pos_embed.unsqueeze(0), patch_pos_embed), dim=1).to(previous_dtype)
 
     def prepare_tokens_with_masks(self, x, masks=None):
-        B, nc, w, h = x.shape
+        if self.is_3d:
+            B, nc, d, w, h = x.shape
+        else:
+            B, nc, w, h = x.shape
         x = self.patch_embed(x)
         if masks is not None:
             # Ensure masks live on same device as activations
@@ -315,7 +361,10 @@ class DinoVisionTransformer(nn.Module):
             x = torch.where(masks.unsqueeze(-1), self.mask_token.to(x.dtype).unsqueeze(0), x)
 
         x = torch.cat((self.cls_token.expand(x.shape[0], -1, -1), x), dim=1)
-        x = x + self.interpolate_pos_encoding(x, w, h)
+        if self.is_3d:
+            x = x + self.interpolate_pos_encoding(x, w, h, d)
+        else:
+            x = x + self.interpolate_pos_encoding(x, w, h)
 
         if self.register_tokens is not None:
             x = torch.cat(

--- a/dinov2/run/eval/embed_clustering.py
+++ b/dinov2/run/eval/embed_clustering.py
@@ -129,6 +129,7 @@ def compute_embeddings(
     is_3d: bool,
     channels_last_npy: bool,
     use_cls: bool = True,
+    use_patch_embed: bool = False,
 ) -> Tuple[np.ndarray, np.ndarray]:
     xs: List[torch.Tensor] = []
     ys: List[int] = []
@@ -139,8 +140,15 @@ def compute_embeddings(
             ys.append(labels[i])
             if len(xs) == batch_size or i == len(files) - 1:
                 xbatch = torch.stack(xs, dim=0).to(device, non_blocking=True)
-                out = model(xbatch, is_training=True)
-                feats = out["x_norm_clstoken"] if use_cls else out["x_norm_patchtokens"].mean(dim=1)
+                if use_patch_embed:
+                    # Extract patch embedding before transformer blocks
+                    with torch.no_grad():
+                        pe = model.patch_embed(xbatch)
+                        # Global average over tokens
+                        feats = pe.mean(dim=1)
+                else:
+                    out = model(xbatch, is_training=True)
+                    feats = out["x_norm_clstoken"] if use_cls else out["x_norm_patchtokens"].mean(dim=1)
                 feats = F.normalize(feats, dim=-1)
                 feats_np = feats.cpu().numpy()
                 if i == len(files) - 1 or len(xs) == batch_size:
@@ -229,6 +237,7 @@ def main():
     parser.add_argument("--device", default="cuda")
     parser.add_argument("--channels-last-npy", action="store_true", help="Set if npy arrays are channels-last")
     parser.add_argument("--use-cls", action="store_true", help="Use CLS token embedding (default). If false, avg patch tokens.")
+    parser.add_argument("--use-patch-embed", action="store_true", help="Use patch embedding (pre-transformer) averaged over tokens")
     parser.add_argument("--projection", default="umap", choices=["umap", "tsne", "pca"])
     parser.add_argument("--metrics-sample-limit", type=int, default=10000)
     parser.add_argument("--max-files-per-class", type=int, default=0)
@@ -260,6 +269,7 @@ def main():
         is_3d=args.is_3d,
         channels_last_npy=args.channels_last_npy,
         use_cls=True if args.use_cls else True,
+        use_patch_embed=bool(args.use_patch_embed),
     )
 
     # Project to 3D and plot

--- a/dinov2/run/eval/embed_clustering.py
+++ b/dinov2/run/eval/embed_clustering.py
@@ -1,0 +1,280 @@
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import List, Tuple
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+from sklearn.decomposition import PCA
+from sklearn.manifold import TSNE
+from sklearn.metrics import calinski_harabasz_score, davies_bouldin_score, silhouette_score
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from mpl_toolkits.mplot3d import Axes3D  # noqa: F401
+
+from dinov2.models import vision_transformer as vits
+
+
+def load_npy_as_tensor(path: Path, is_3d: bool, channels_last: bool) -> torch.Tensor:
+    arr = np.load(str(path))
+    # Ensure float32
+    arr = arr.astype(np.float32, copy=False)
+    # Replace NaNs with zeros to avoid propagation
+    np.nan_to_num(arr, copy=False)
+    t = torch.from_numpy(arr)
+    # Add channel dimension if missing
+    if is_3d:
+        # expected [C,D,H,W] or [D,H,W] or [D,H,W,C]
+        if t.dim() == 3:  # [D,H,W]
+            t = t.unsqueeze(0)
+        elif t.dim() == 4 and channels_last:  # [D,H,W,C] -> [C,D,H,W]
+            t = t.permute(3, 0, 1, 2)
+        elif t.dim() == 4:  # assume [C,D,H,W]
+            pass
+        else:
+            raise ValueError(f"Unsupported 3D array shape for {path}: {tuple(t.shape)}")
+    else:
+        # expected [C,H,W] or [H,W] or [H,W,C]
+        if t.dim() == 2:  # [H,W]
+            t = t.unsqueeze(0)
+        elif t.dim() == 3 and channels_last:  # [H,W,C] -> [C,H,W]
+            t = t.permute(2, 0, 1)
+        elif t.dim() == 3:  # [C,H,W]
+            pass
+        else:
+            raise ValueError(f"Unsupported 2D array shape for {path}: {tuple(t.shape)}")
+    return t
+
+
+def adapt_2d_state_to_3d(model: torch.nn.Module, state: dict) -> dict:
+    """Inflate 2D ViT weights to 3D for PatchEmbed and positional embeddings."""
+    new_state = dict(state)
+    # patch embed
+    pe_w_key = "patch_embed.proj.weight"
+    if pe_w_key in state and state[pe_w_key].ndim == 4:
+        w2d = state[pe_w_key]  # [E, Cin, Kh, Kw]
+        kd = model.patch_embed.proj.weight.shape[2]
+        w3d = w2d.unsqueeze(2).repeat(1, 1, kd, 1, 1) / kd
+        new_state[pe_w_key] = w3d
+    # pos embed
+    pos_key = "pos_embed"
+    if pos_key in state:
+        pos2d = state[pos_key]
+        if pos2d.ndim == 3 and pos2d.shape[0] == 1:
+            cls_pos = pos2d[:, :1, :]
+            patch_pos = pos2d[:, 1:, :]
+            n2 = patch_pos.shape[1]
+            c = patch_pos.shape[2]
+            m = int(np.sqrt(n2))
+            if m * m == n2 and hasattr(model.patch_embed, "patches_resolution") and len(model.patch_embed.patches_resolution) == 3:
+                d0, h0, w0 = model.patch_embed.patches_resolution
+                patch_pos_2d = patch_pos.view(1, m, m, c).permute(0, 3, 1, 2)  # [1,C,M,M]
+                patch_pos_3d = F.interpolate(
+                    patch_pos_2d.unsqueeze(2), size=(d0, h0, w0), mode="trilinear", align_corners=False
+                ).squeeze(2)
+                patch_pos_flat = patch_pos_3d.permute(0, 2, 3, 1).reshape(1, d0 * h0 * w0, c)
+                new_state[pos_key] = torch.cat([cls_pos, patch_pos_flat], dim=1)
+    return new_state
+
+
+def build_model(arch: str, patch_size: int, is_3d: bool, num_register_tokens: int = 0, img_size: int = 224) -> torch.nn.Module:
+    fn = getattr(vits, arch)
+    model = fn(patch_size=patch_size, num_register_tokens=num_register_tokens, is_3d=is_3d, img_size=img_size)
+    model.eval()
+    return model
+
+
+def load_weights(model: torch.nn.Module, weights_path: str, is_3d: bool) -> None:
+    ckpt = torch.load(weights_path, map_location="cpu")
+    state = ckpt.get("teacher") or ckpt.get("model") or ckpt
+    # Adapt if needed
+    if is_3d:
+        # Detect 2D kernel
+        pe_w_key = "patch_embed.proj.weight"
+        if pe_w_key in state and state[pe_w_key].ndim == 4:
+            state = adapt_2d_state_to_3d(model, state)
+    missing, unexpected = model.load_state_dict(state, strict=False)
+    if missing:
+        print(f"[load] missing keys: {len(missing)}")
+    if unexpected:
+        print(f"[load] unexpected keys: {len(unexpected)}")
+
+
+def collect_files_by_class(root: str, max_files_per_class: int = 0) -> Tuple[List[str], List[int], List[str]]:
+    root_p = Path(root)
+    classes = sorted([d.name for d in root_p.iterdir() if d.is_dir()])
+    file_paths: List[str] = []
+    labels: List[int] = []
+    class_names: List[str] = []
+    for ci, cname in enumerate(classes):
+        npys = sorted((root_p / cname).glob("*.npy"))
+        if max_files_per_class > 0:
+            npys = npys[: max_files_per_class]
+        for p in npys:
+            file_paths.append(str(p))
+            labels.append(ci)
+        class_names.append(cname)
+    return file_paths, labels, class_names
+
+
+def compute_embeddings(
+    model: torch.nn.Module,
+    files: List[str],
+    labels: List[int],
+    device: str,
+    batch_size: int,
+    is_3d: bool,
+    channels_last_npy: bool,
+    use_cls: bool = True,
+) -> Tuple[np.ndarray, np.ndarray]:
+    xs: List[torch.Tensor] = []
+    ys: List[int] = []
+    with torch.no_grad():
+        for i, fp in enumerate(files):
+            t = load_npy_as_tensor(Path(fp), is_3d=is_3d, channels_last=channels_last_npy)
+            xs.append(t)
+            ys.append(labels[i])
+            if len(xs) == batch_size or i == len(files) - 1:
+                xbatch = torch.stack(xs, dim=0).to(device, non_blocking=True)
+                out = model(xbatch, is_training=True)
+                feats = out["x_norm_clstoken"] if use_cls else out["x_norm_patchtokens"].mean(dim=1)
+                feats = F.normalize(feats, dim=-1)
+                feats_np = feats.cpu().numpy()
+                if i == len(files) - 1 or len(xs) == batch_size:
+                    if i == batch_size - 1:
+                        emb = feats_np
+                        ys_np = np.array(ys, dtype=np.int64)
+                    else:
+                        try:
+                            emb = np.vstack((emb, feats_np))  # type: ignore[name-defined]
+                            ys_np = np.concatenate((ys_np, np.array(ys, dtype=np.int64)))  # type: ignore[name-defined]
+                        except NameError:
+                            emb = feats_np
+                            ys_np = np.array(ys, dtype=np.int64)
+                xs.clear()
+                ys.clear()
+    return emb, ys_np
+
+
+def project_to_3d(emb: np.ndarray, method: str = "umap", random_state: int = 0) -> np.ndarray:
+    if method.lower() == "umap":
+        try:
+            import umap
+            reducer = umap.UMAP(n_components=3, random_state=random_state)
+            return reducer.fit_transform(emb)
+        except Exception:
+            pass
+    if method.lower() == "tsne":
+        proj = TSNE(n_components=3, random_state=random_state, init="pca", learning_rate="auto").fit_transform(emb)
+        return proj
+    # fallback to PCA
+    proj = PCA(n_components=3, random_state=random_state).fit_transform(emb)
+    return proj
+
+
+def compute_metrics(emb: np.ndarray, labels: np.ndarray, sample_limit: int = 10000, random_state: int = 0) -> dict:
+    n = emb.shape[0]
+    if n > sample_limit:
+        rng = np.random.default_rng(random_state)
+        idx = rng.choice(n, size=sample_limit, replace=False)
+        E = emb[idx]
+        y = labels[idx]
+    else:
+        E = emb
+        y = labels
+    metrics = {}
+    # Silhouette can be expensive; try/catch
+    try:
+        metrics["silhouette"] = float(silhouette_score(E, y, metric="euclidean"))
+    except Exception as e:
+        metrics["silhouette"] = None
+    try:
+        metrics["davies_bouldin"] = float(davies_bouldin_score(E, y))
+    except Exception:
+        metrics["davies_bouldin"] = None
+    try:
+        metrics["calinski_harabasz"] = float(calinski_harabasz_score(E, y))
+    except Exception:
+        metrics["calinski_harabasz"] = None
+    return metrics
+
+
+def save_3d_plot(proj3d: np.ndarray, labels: np.ndarray, class_names: List[str], out_path: str) -> None:
+    fig = plt.figure(figsize=(10, 8))
+    ax = fig.add_subplot(111, projection="3d")
+    num_classes = len(class_names)
+    cmap = plt.get_cmap("tab20")
+    for ci in range(num_classes):
+        idx = labels == ci
+        ax.scatter(proj3d[idx, 0], proj3d[idx, 1], proj3d[idx, 2], s=6, alpha=0.7, color=cmap(ci % 20), label=class_names[ci])
+    ax.set_title("Embedding Clusters (3D)")
+    ax.legend(loc="best", fontsize=8, markerscale=2)
+    plt.tight_layout()
+    plt.savefig(out_path, dpi=200)
+    plt.close(fig)
+
+
+def main():
+    parser = argparse.ArgumentParser("Embedding clustering evaluation")
+    parser.add_argument("--data-root", required=True, help="Root folder with class subfolders containing .npy files")
+    parser.add_argument("--weights", required=True, help="Path to pretrained weights (teacher/model or full state dict)")
+    parser.add_argument("--arch", default="vit_large", help="ViT arch: vit_small|vit_base|vit_large|vit_giant2")
+    parser.add_argument("--patch-size", type=int, default=16)
+    parser.add_argument("--is-3d", action="store_true")
+    parser.add_argument("--img-size", type=int, default=224)
+    parser.add_argument("--batch-size", type=int, default=16)
+    parser.add_argument("--device", default="cuda")
+    parser.add_argument("--channels-last-npy", action="store_true", help="Set if npy arrays are channels-last")
+    parser.add_argument("--use-cls", action="store_true", help="Use CLS token embedding (default). If false, avg patch tokens.")
+    parser.add_argument("--projection", default="umap", choices=["umap", "tsne", "pca"])
+    parser.add_argument("--metrics-sample-limit", type=int, default=10000)
+    parser.add_argument("--max-files-per-class", type=int, default=0)
+    parser.add_argument("--output-dir", default="eval_embed_out")
+    parser.add_argument("--seed", type=int, default=0)
+
+    args = parser.parse_args()
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    device = torch.device(args.device if torch.cuda.is_available() else "cpu")
+
+    # Build and load model
+    model = build_model(args.arch, args.patch_size, args.is_3d, img_size=args.img_size)
+    load_weights(model, args.weights, is_3d=args.is_3d)
+    model.to(device)
+    model.eval()
+
+    # Collect files
+    files, labels, class_names = collect_files_by_class(args.data_root, args.max_files_per_class)
+    print(f"Found {len(files)} files across {len(class_names)} classes")
+
+    # Compute embeddings
+    emb, y_np = compute_embeddings(
+        model,
+        files,
+        labels,
+        device=str(device),
+        batch_size=args.batch_size,
+        is_3d=args.is_3d,
+        channels_last_npy=args.channels_last_npy,
+        use_cls=True if args.use_cls else True,
+    )
+
+    # Project to 3D and plot
+    proj3d = project_to_3d(emb, method=args.projection, random_state=args.seed)
+    plot_path = os.path.join(args.output_dir, "embed_3d.png")
+    save_3d_plot(proj3d, y_np, class_names, plot_path)
+
+    # Metrics
+    metrics = compute_metrics(emb, y_np, sample_limit=args.metrics_sample_limit, random_state=args.seed)
+    metrics_path = os.path.join(args.output_dir, "metrics.json")
+    with open(metrics_path, "w") as f:
+        json.dump(metrics, f, indent=2)
+    print("Saved:", plot_path)
+    print("Metrics:", metrics)
+
+
+if __name__ == "__main__":
+    main()

--- a/dinov2/train/ssl_meta_arch.py
+++ b/dinov2/train/ssl_meta_arch.py
@@ -6,8 +6,10 @@
 from functools import partial
 import logging
 
+import math
 import torch
 import torch.distributed as dist
+import torch.nn.functional as F
 from torch import nn
 
 from dinov2.loss import DINOLoss, iBOTPatchLoss, KoLeoLoss
@@ -45,9 +47,17 @@ class SSLMetaArch(nn.Module):
         logger.info(f"OPTIONS -- architecture : embed_dim: {embed_dim}")
 
         if cfg.student.pretrained_weights:
-            chkpt = torch.load(cfg.student.pretrained_weights)
+            chkpt = torch.load(cfg.student.pretrained_weights, map_location="cpu")
             logger.info(f"OPTIONS -- pretrained weights: loading from {cfg.student.pretrained_weights}")
-            student_backbone.load_state_dict(chkpt["model"], strict=False)
+            state = chkpt.get("model", chkpt)
+            # If 3D backbone but checkpoint is 2D, adapt weights
+            if getattr(student_backbone, "is_3d", False):
+                state = self._adapt_2d_backbone_state_for_3d(student_backbone, state)
+            missing, unexpected = student_backbone.load_state_dict(state, strict=False)
+            if missing:
+                logger.info(f"pretrained load - missing keys: {len(missing)}")
+            if unexpected:
+                logger.info(f"pretrained load - unexpected keys: {len(unexpected)}")
 
         self.embed_dim = embed_dim
         self.dino_out_dim = cfg.dino.head_n_prototypes
@@ -153,6 +163,49 @@ class SSLMetaArch(nn.Module):
         self.freq_mask_per_sample = bool(getattr(fm_cfg, "per_sample", False)) if fm_cfg is not None else False
         self.freq_mask_low_range = tuple(getattr(fm_cfg, "low_range", (self.freq_mask_low, self.freq_mask_low)))
         self.freq_mask_high_range = tuple(getattr(fm_cfg, "high_range", (self.freq_mask_high, self.freq_mask_high)))
+
+    @staticmethod
+    def _adapt_2d_backbone_state_for_3d(model: nn.Module, state: dict) -> dict:
+        """Inflate 2D ViT weights to 3D for PatchEmbed and positional embeddings.
+
+        - patch_embed.proj.weight: [C_out, C_in, Kh, Kw] -> [C_out, C_in, Kd, Kh, Kw] by repeat/avg
+        - pos_embed: interpolate 2D grid to target 3D grid (D',H',W') using trilinear with depth=1 source
+        Other parameters are copied as-is.
+        """
+        new_state = dict(state)
+        # Adapt patch embedding conv
+        pe_w_key = "patch_embed.proj.weight"
+        if pe_w_key in state and state[pe_w_key].ndim == 4:
+            w2d = state[pe_w_key]  # [E, Cin, Kh, Kw]
+            kd = getattr(getattr(model, "patch_embed", None), "proj", None).weight.shape[2]
+            # Inflate by repeating along depth and average
+            w3d = w2d.unsqueeze(2).repeat(1, 1, kd, 1, 1) / kd
+            new_state[pe_w_key] = w3d
+
+        # Adapt positional embedding
+        pos_key = "pos_embed"
+        if pos_key in state:
+            pos2d = state[pos_key]  # [1, N2+1, C]
+            if pos2d.ndim == 3 and pos2d.shape[0] == 1:
+                cls_pos = pos2d[:, :1, :]
+                patch_pos = pos2d[:, 1:, :]
+                n2 = patch_pos.shape[1]
+                c = patch_pos.shape[2]
+                m = int(math.sqrt(n2))
+                if m * m == n2:
+                    target_res = getattr(getattr(model, "patch_embed", None), "patches_resolution", None)
+                    if isinstance(target_res, tuple) and len(target_res) == 3:
+                        d0, h0, w0 = target_res
+                        patch_pos_2d = patch_pos.view(1, m, m, c).permute(0, 3, 1, 2)  # [1,C,M,M]
+                        patch_pos_3d = F.interpolate(
+                            patch_pos_2d.unsqueeze(2),  # [1,C,1,M,M]
+                            size=(d0, h0, w0),
+                            mode="trilinear",
+                            align_corners=False,
+                        ).squeeze(2)
+                        patch_pos_flat = patch_pos_3d.permute(0, 2, 3, 1).reshape(1, d0 * h0 * w0, c)
+                        new_state[pos_key] = torch.cat([cls_pos, patch_pos_flat], dim=1)
+        return new_state
 
     @staticmethod
     def _broadcast_model_parameters(module_dict: nn.ModuleDict):

--- a/dinov2/train/ssl_meta_arch.py
+++ b/dinov2/train/ssl_meta_arch.py
@@ -120,6 +120,17 @@ class SSLMetaArch(nn.Module):
             p.requires_grad = False
         logger.info(f"Student and Teacher are built: they are both {cfg.student.arch} network.")
 
+        # If backbone uses model-parallel, place heads on last device and disable FSDP stream sync
+        if getattr(self.student["backbone"], "model_parallel", False):
+            last_device = self.student["backbone"].mp_devices[-1]
+            if "dino_head" in self.student:
+                self.student["dino_head"].to(last_device)
+                self.teacher["dino_head"].to(last_device)
+            if "ibot_head" in self.student:
+                self.student["ibot_head"].to(last_device)
+                self.teacher["ibot_head"].to(last_device)
+            self.need_to_synchronize_fsdp_streams = False
+
     def forward(self, inputs):
         raise NotImplementedError
 
@@ -134,15 +145,21 @@ class SSLMetaArch(nn.Module):
         assert n_global_crops == 2
         n_local_crops = self.cfg.crops.local_crops_number
 
-        global_crops = images["collated_global_crops"].cuda(non_blocking=True)
-        local_crops = images["collated_local_crops"].cuda(non_blocking=True)
+        # Choose device for inputs: first MP device if model-parallel, else current cuda device
+        if getattr(self.student["backbone"], "model_parallel", False):
+            device0 = self.student["backbone"].mp_devices[0]
+        else:
+            device0 = torch.device("cuda")
 
-        masks = images["collated_masks"].cuda(non_blocking=True)
-        mask_indices_list = images["mask_indices_list"].cuda(non_blocking=True)
-        n_masked_patches_tensor = images["n_masked_patches"].cuda(non_blocking=True)
+        global_crops = images["collated_global_crops"].to(device0, non_blocking=True)
+        local_crops = images["collated_local_crops"].to(device0, non_blocking=True)
+
+        masks = images["collated_masks"].to(device0, non_blocking=True)
+        mask_indices_list = images["mask_indices_list"].to(device0, non_blocking=True)
+        n_masked_patches_tensor = images["n_masked_patches"].to(device0, non_blocking=True)
         n_masked_patches = mask_indices_list.shape[0]
         upperbound = images["upperbound"]
-        masks_weight = images["masks_weight"].cuda(non_blocking=True)
+            masks_weight = images["masks_weight"].to(device0, non_blocking=True)
 
         n_local_crops_loss_terms = max(n_local_crops * n_global_crops, 1)
         n_global_crops_loss_terms = (n_global_crops - 1) * n_global_crops
@@ -389,6 +406,15 @@ class SSLMetaArch(nn.Module):
 
     def prepare_for_distributed_training(self):
         logger.info("DISTRIBUTED FSDP -- preparing model for distributed training")
+        # If model-parallel is enabled on backbone, skip FSDP wrapping because
+        # FSDP cannot shard parameters spanning multiple devices in a single module.
+        if getattr(self.student["backbone"], "model_parallel", False):
+            logger.info("Model-parallel backbone detected; skipping FSDP wrapping.")
+            # Still sync teacher weights from student
+            for k in self.student.keys():
+                self.teacher[k].load_state_dict(self.student[k].state_dict())
+            return
+
         if has_batchnorms(self.student):
             raise NotImplementedError
         # below will synchronize all student subnetworks across gpus:

--- a/dinov2/train/ssl_meta_arch.py
+++ b/dinov2/train/ssl_meta_arch.py
@@ -7,6 +7,7 @@ from functools import partial
 import logging
 
 import torch
+import torch.distributed as dist
 from torch import nn
 
 from dinov2.loss import DINOLoss, iBOTPatchLoss, KoLeoLoss
@@ -15,6 +16,7 @@ from dinov2.layers import DINOHead
 from dinov2.utils.utils import has_batchnorms
 from dinov2.utils.param_groups import get_params_groups_with_decay, fuse_params_groups
 from dinov2.fsdp import get_fsdp_wrapper, ShardedGradScaler, get_fsdp_modules, reshard_fsdp_model
+import dinov2.distributed as distributed
 
 from dinov2.models.vision_transformer import BlockChunk
 
@@ -122,6 +124,12 @@ class SSLMetaArch(nn.Module):
 
         # If backbone uses model-parallel, place heads on last device and disable FSDP stream sync
         if getattr(self.student["backbone"], "model_parallel", False):
+            # Require single process per node when using intra-node model-parallel
+            if distributed.get_local_size() != 1:
+                raise RuntimeError(
+                    "Model-parallel backbone requires one process per node (LOCAL_WORLD_SIZE=1). "
+                    "Launch with torchrun --nproc_per_node=1 and set student.mp_devices to GPUs per node."
+                )
             last_device = self.student["backbone"].mp_devices[-1]
             if "dino_head" in self.student:
                 self.student["dino_head"].to(last_device)
@@ -130,6 +138,24 @@ class SSLMetaArch(nn.Module):
                 self.student["ibot_head"].to(last_device)
                 self.teacher["ibot_head"].to(last_device)
             self.need_to_synchronize_fsdp_streams = False
+            # Broadcast initial weights across nodes when distributed is enabled
+            if distributed.get_global_size() > 1:
+                self._broadcast_model_parameters(self.student)
+                self._broadcast_model_parameters(self.teacher)
+
+    @staticmethod
+    def _broadcast_model_parameters(module_dict: nn.ModuleDict):
+        if not dist.is_available() or not dist.is_initialized():
+            return
+        # Use device0 per process to perform NCCL broadcasts to remain compatible with single-device NCCL groups
+        device0 = torch.device("cuda:0")
+        for m in module_dict.values():
+            for p in m.state_dict().values():
+                if isinstance(p, torch.Tensor):
+                    tmp = p.to(device0, non_blocking=True)
+                    dist.broadcast(tmp, src=0)
+                    if tmp.data_ptr() != p.data_ptr():
+                        p.copy_(tmp.to(p.device, non_blocking=True))
 
     def forward(self, inputs):
         raise NotImplementedError
@@ -357,6 +383,19 @@ class SSLMetaArch(nn.Module):
             loss_accumulator += self.ibot_loss_weight * ibot_patch_loss
 
         self.backprop_loss(loss_accumulator)
+
+        # Average gradients across nodes when using model-parallel without FSDP/DDP
+        if getattr(self.student["backbone"], "model_parallel", False) and distributed.get_global_size() > 1:
+            world_size = distributed.get_global_size()
+            device0 = torch.device("cuda:0")
+            for sub in self.student.values():
+                for p in sub.parameters():
+                    if p.grad is None:
+                        continue
+                    tmp = p.grad.detach().to(device0, non_blocking=True)
+                    dist.all_reduce(tmp, op=dist.ReduceOp.SUM)
+                    tmp.div_(world_size)
+                    p.grad.copy_(tmp.to(p.grad.device, non_blocking=True))
 
         self.fsdp_synchronize_streams()
 

--- a/dinov2/train/ssl_meta_arch.py
+++ b/dinov2/train/ssl_meta_arch.py
@@ -143,6 +143,14 @@ class SSLMetaArch(nn.Module):
                 self._broadcast_model_parameters(self.student)
                 self._broadcast_model_parameters(self.teacher)
 
+        # Configure optional frequency-domain masking for iBOT inputs
+        fm_cfg = getattr(cfg.ibot, "freq_mask", None)
+        self.freq_mask_enabled = bool(getattr(fm_cfg, "enabled", False)) if fm_cfg is not None else False
+        self.freq_mask_prob = float(getattr(fm_cfg, "prob", 0.0)) if fm_cfg is not None else 0.0
+        self.freq_mask_low = float(getattr(fm_cfg, "low", 0.0)) if fm_cfg is not None else 0.0
+        self.freq_mask_high = float(getattr(fm_cfg, "high", 0.0)) if fm_cfg is not None else 0.0
+        self.freq_mask_mode = str(getattr(fm_cfg, "mode", "bandpass")) if fm_cfg is not None else "bandpass"
+
     @staticmethod
     def _broadcast_model_parameters(module_dict: nn.ModuleDict):
         if not dist.is_available() or not dist.is_initialized():
@@ -180,12 +188,19 @@ class SSLMetaArch(nn.Module):
         global_crops = images["collated_global_crops"].to(device0, non_blocking=True)
         local_crops = images["collated_local_crops"].to(device0, non_blocking=True)
 
+        # Optional frequency-domain masking on inputs before teacher/student forward
+        if self.freq_mask_enabled and self.freq_mask_prob > 0.0:
+            if torch.rand((), device=global_crops.device).item() < self.freq_mask_prob:
+                global_crops = self._apply_frequency_mask(global_crops, self.freq_mask_low, self.freq_mask_high, self.freq_mask_mode)
+                if local_crops.numel() > 0:
+                    local_crops = self._apply_frequency_mask(local_crops, self.freq_mask_low, self.freq_mask_high, self.freq_mask_mode)
+
         masks = images["collated_masks"].to(device0, non_blocking=True)
         mask_indices_list = images["mask_indices_list"].to(device0, non_blocking=True)
         n_masked_patches_tensor = images["n_masked_patches"].to(device0, non_blocking=True)
         n_masked_patches = mask_indices_list.shape[0]
         upperbound = images["upperbound"]
-            masks_weight = images["masks_weight"].to(device0, non_blocking=True)
+        masks_weight = images["masks_weight"].to(device0, non_blocking=True)
 
         n_local_crops_loss_terms = max(n_local_crops * n_global_crops, 1)
         n_global_crops_loss_terms = (n_global_crops - 1) * n_global_crops
@@ -400,6 +415,60 @@ class SSLMetaArch(nn.Module):
         self.fsdp_synchronize_streams()
 
         return loss_dict
+
+    @staticmethod
+    def _build_frequency_mask(shape_spatial: torch.Size, device: torch.device, low: float, high: float, mode: str):
+        # shape_spatial: (..., H, W) or (..., D, H, W) but we only need last 2/3
+        if len(shape_spatial) == 2:
+            H, W = shape_spatial
+            fy = torch.fft.fftfreq(H, device=device)
+            fx = torch.fft.fftfreq(W, device=device)
+            grid_y, grid_x = torch.meshgrid(fy, fx, indexing="ij")
+            r = torch.sqrt(grid_x**2 + grid_y**2)
+        elif len(shape_spatial) == 3:
+            D, H, W = shape_spatial
+            fz = torch.fft.fftfreq(D, device=device)
+            fy = torch.fft.fftfreq(H, device=device)
+            fx = torch.fft.fftfreq(W, device=device)
+            grid_z, grid_y, grid_x = torch.meshgrid(fz, fy, fx, indexing="ij")
+            r = torch.sqrt(grid_x**2 + grid_y**2 + grid_z**2)
+        else:
+            raise ValueError("Unsupported spatial rank for frequency mask")
+
+        if mode == "bandpass":
+            mask = (r >= low) & (r <= high)
+        elif mode == "lowpass":
+            mask = (r <= high)
+        elif mode == "highpass":
+            mask = (r >= low)
+        else:
+            raise ValueError(f"Unknown freq mask mode: {mode}")
+        return mask
+
+    def _apply_frequency_mask(self, x: torch.Tensor, low: float, high: float, mode: str) -> torch.Tensor:
+        # x: [N,C,H,W] or [N,C,D,H,W]
+        original_dtype = x.dtype
+        if x.dim() == 4:
+            N, C, H, W = x.shape
+            spatial = (H, W)
+            dims = (-2, -1)
+        elif x.dim() == 5:
+            N, C, D, H, W = x.shape
+            spatial = (D, H, W)
+            dims = (-3, -2, -1)
+        else:
+            return x
+
+        mask = self._build_frequency_mask(spatial, x.device, low, high, mode)
+        # Broadcast mask to [1,1,...spatial]
+        while mask.dim() < x.dim():
+            mask = mask.unsqueeze(0)
+        mask = mask.to(x.device)
+
+        X = torch.fft.fftn(x.float(), dim=dims)
+        X = X * mask
+        y = torch.fft.ifftn(X, dim=dims).real.to(original_dtype)
+        return y
 
     def fsdp_synchronize_streams(self):
         if self.need_to_synchronize_fsdp_streams:

--- a/dinov2/train/ssl_meta_arch.py
+++ b/dinov2/train/ssl_meta_arch.py
@@ -371,15 +371,21 @@ class SSLMetaArch(nn.Module):
             self.need_to_synchronize_fsdp_streams = False
 
     def update_teacher(self, m):
-        student_param_list = []
-        teacher_param_list = []
         with torch.no_grad():
-            for k in self.student.keys():
-                for ms, mt in zip(get_fsdp_modules(self.student[k]), get_fsdp_modules(self.teacher[k])):
-                    student_param_list += ms.params
-                    teacher_param_list += mt.params
-            torch._foreach_mul_(teacher_param_list, m)
-            torch._foreach_add_(teacher_param_list, student_param_list, alpha=1 - m)
+            if any(get_fsdp_modules(self.student[k]) for k in self.student.keys()):
+                student_param_list = []
+                teacher_param_list = []
+                for k in self.student.keys():
+                    for ms, mt in zip(get_fsdp_modules(self.student[k]), get_fsdp_modules(self.teacher[k])):
+                        student_param_list += ms.params
+                        teacher_param_list += mt.params
+                torch._foreach_mul_(teacher_param_list, m)
+                torch._foreach_add_(teacher_param_list, student_param_list, alpha=1 - m)
+            else:
+                # Fallback when not using FSDP (e.g., model-parallel backbone)
+                for k in self.student.keys():
+                    for p_s, p_t in zip(self.student[k].parameters(), self.teacher[k].parameters()):
+                        p_t.mul_(m).add_(p_s, alpha=1 - m)
 
     def train(self):
         super().train()

--- a/dinov2/train/ssl_meta_arch.py
+++ b/dinov2/train/ssl_meta_arch.py
@@ -150,6 +150,9 @@ class SSLMetaArch(nn.Module):
         self.freq_mask_low = float(getattr(fm_cfg, "low", 0.0)) if fm_cfg is not None else 0.0
         self.freq_mask_high = float(getattr(fm_cfg, "high", 0.0)) if fm_cfg is not None else 0.0
         self.freq_mask_mode = str(getattr(fm_cfg, "mode", "bandpass")) if fm_cfg is not None else "bandpass"
+        self.freq_mask_per_sample = bool(getattr(fm_cfg, "per_sample", False)) if fm_cfg is not None else False
+        self.freq_mask_low_range = tuple(getattr(fm_cfg, "low_range", (self.freq_mask_low, self.freq_mask_low)))
+        self.freq_mask_high_range = tuple(getattr(fm_cfg, "high_range", (self.freq_mask_high, self.freq_mask_high)))
 
     @staticmethod
     def _broadcast_model_parameters(module_dict: nn.ModuleDict):
@@ -190,10 +193,34 @@ class SSLMetaArch(nn.Module):
 
         # Optional frequency-domain masking on inputs before teacher/student forward
         if self.freq_mask_enabled and self.freq_mask_prob > 0.0:
-            if torch.rand((), device=global_crops.device).item() < self.freq_mask_prob:
-                global_crops = self._apply_frequency_mask(global_crops, self.freq_mask_low, self.freq_mask_high, self.freq_mask_mode)
-                if local_crops.numel() > 0:
-                    local_crops = self._apply_frequency_mask(local_crops, self.freq_mask_low, self.freq_mask_high, self.freq_mask_mode)
+            if not self.freq_mask_per_sample:
+                if torch.rand((), device=global_crops.device).item() < self.freq_mask_prob:
+                    global_crops = self._apply_frequency_mask(global_crops, self.freq_mask_low, self.freq_mask_high, self.freq_mask_mode)
+                    if local_crops.numel() > 0:
+                        local_crops = self._apply_frequency_mask(local_crops, self.freq_mask_low, self.freq_mask_high, self.freq_mask_mode)
+            else:
+                # Sample-wise random cutoffs within ranges; bandpass by default
+                def _sample_cutoffs(n: int, device: torch.device):
+                    lo_min, lo_max = self.freq_mask_low_range
+                    hi_min, hi_max = self.freq_mask_high_range
+                    lows = torch.empty(n, device=device).uniform_(lo_min, lo_max)
+                    highs = torch.empty(n, device=device).uniform_(hi_min, hi_max)
+                    highs = torch.maximum(highs, lows + 1e-4)
+                    return lows, highs
+
+                # Apply to each sample independently
+                def _apply_per_sample(x: torch.Tensor):
+                    B = x.shape[0]
+                    lows, highs = _sample_cutoffs(B, x.device)
+                    out_list = []
+                    for i in range(B):
+                        out_list.append(self._apply_frequency_mask(x[i:i+1], float(lows[i].item()), float(highs[i].item()), self.freq_mask_mode))
+                    return torch.cat(out_list, dim=0)
+
+                if torch.rand((), device=global_crops.device).item() < self.freq_mask_prob:
+                    global_crops = _apply_per_sample(global_crops)
+                    if local_crops.numel() > 0:
+                        local_crops = _apply_per_sample(local_crops)
 
         masks = images["collated_masks"].to(device0, non_blocking=True)
         mask_indices_list = images["mask_indices_list"].to(device0, non_blocking=True)

--- a/dinov2/train/ssl_meta_arch.py
+++ b/dinov2/train/ssl_meta_arch.py
@@ -14,7 +14,7 @@ from torch import nn
 
 from dinov2.loss import DINOLoss, iBOTPatchLoss, KoLeoLoss
 from dinov2.models import build_model_from_cfg
-from dinov2.layers import DINOHead
+from dinov2.layers import DINOHead, apply_lora_to_vit
 from dinov2.utils.utils import has_batchnorms
 from dinov2.utils.param_groups import get_params_groups_with_decay, fuse_params_groups
 from dinov2.fsdp import get_fsdp_wrapper, ShardedGradScaler, get_fsdp_modules, reshard_fsdp_model
@@ -42,6 +42,18 @@ class SSLMetaArch(nn.Module):
         teacher_model_dict = dict()
 
         student_backbone, teacher_backbone, embed_dim = build_model_from_cfg(cfg)
+        # Optionally apply LoRA adapters to ViT
+        if getattr(cfg.student, "lora", None) is not None and cfg.student.lora.enabled:
+            lora_cfg = cfg.student.lora
+            student_backbone = apply_lora_to_vit(
+                student_backbone,
+                target_substrings=tuple(lora_cfg.get("targets", ["qkv", "proj", "fc1", "fc2"])),
+                r=int(lora_cfg.get("r", 8)),
+                alpha=float(lora_cfg.get("alpha", 16.0)),
+                dropout=float(lora_cfg.get("dropout", 0.0)),
+            )
+            logger.info("Applied LoRA adapters to student backbone")
+
         student_model_dict["backbone"] = student_backbone
         teacher_model_dict["backbone"] = teacher_backbone
         logger.info(f"OPTIONS -- architecture : embed_dim: {embed_dim}")

--- a/dinov2/train/train.py
+++ b/dinov2/train/train.py
@@ -297,7 +297,11 @@ def do_train(cfg, model, resume=False):
 def main(args):
     cfg = setup(args)
 
-    model = SSLMetaArch(cfg).to(torch.device("cuda"))
+    # If backbone is configured for model-parallel, we should not move the
+    # whole container to a single device. The submodules are already placed.
+    model = SSLMetaArch(cfg)
+    if not getattr(model.student["backbone"], "model_parallel", False):
+        model = model.to(torch.device("cuda"))
     model.prepare_for_distributed_training()
 
     logger.info("Model:\n{}".format(model))

--- a/dinov2/train/train.py
+++ b/dinov2/train/train.py
@@ -206,6 +206,12 @@ def do_train(cfg, model, resume=False):
     )
     # sampler_type = SamplerType.INFINITE
     sampler_type = SamplerType.SHARDED_INFINITE
+    # Set PyTorch multiprocessing sharing strategy to reduce shared memory pressure if configured
+    if hasattr(cfg.train, "shm_sharing_strategy"):
+        import torch.multiprocessing as mp
+
+        mp.set_sharing_strategy(str(cfg.train.shm_sharing_strategy))
+
     data_loader = make_data_loader(
         dataset=dataset,
         batch_size=cfg.train.batch_size_per_gpu,
@@ -216,6 +222,9 @@ def do_train(cfg, model, resume=False):
         sampler_advance=0,  # TODO(qas): fix this -- start_iter * cfg.train.batch_size_per_gpu,
         drop_last=True,
         collate_fn=collate_fn,
+        pin_memory=bool(cfg.train.get("pin_memory", True)),
+        prefetch_factor=int(cfg.train.get("prefetch_factor", 2)),
+        persistent_workers=bool(cfg.train.get("persistent_workers", False)),
     )
 
     # training loop

--- a/dinov2/train/train.py
+++ b/dinov2/train/train.py
@@ -148,7 +148,15 @@ def do_train(cfg, model, resume=False):
     ) = build_schedulers(cfg)
 
     # checkpointer
-    checkpointer = FSDPCheckpointer(model, cfg.train.output_dir, optimizer=optimizer, save_to_disk=True)
+    if getattr(model.student["backbone"], "model_parallel", False):
+        # Use a simple checkpointing when not using FSDP
+        from fvcore.common.checkpoint import Checkpointer
+
+        checkpointer = Checkpointer(
+            model, cfg.train.output_dir, optimizer=optimizer, save_to_disk=distributed.is_main_process()
+        )
+    else:
+        checkpointer = FSDPCheckpointer(model, cfg.train.output_dir, optimizer=optimizer, save_to_disk=True)
 
     start_iter = checkpointer.resume_or_load(cfg.MODEL.WEIGHTS, resume=resume).get("iteration", -1) + 1
 

--- a/dinov2/train/train.py
+++ b/dinov2/train/train.py
@@ -281,13 +281,22 @@ def do_train(cfg, model, resume=False):
                 fp16_scaler.unscale_(optimizer)
                 for v in model.student.values():
                     v.clip_grad_norm_(cfg.optim.clip_grad)
-            fp16_scaler.step(optimizer)
-            fp16_scaler.update()
+            if int(cfg.train.get("accumulate_steps", 1)) > 1:
+                if (iteration + 1) % int(cfg.train.get("accumulate_steps", 1)) == 0:
+                    fp16_scaler.step(optimizer)
+                    fp16_scaler.update()
+            else:
+                fp16_scaler.step(optimizer)
+                fp16_scaler.update()
         else:
             if cfg.optim.clip_grad:
                 for v in model.student.values():
                     v.clip_grad_norm_(cfg.optim.clip_grad)
-            optimizer.step()
+            if int(cfg.train.get("accumulate_steps", 1)) > 1:
+                if (iteration + 1) % int(cfg.train.get("accumulate_steps", 1)) == 0:
+                    optimizer.step()
+            else:
+                optimizer.step()
 
         # perform teacher EMA update
 
@@ -332,6 +341,16 @@ def main(args):
     model = SSLMetaArch(cfg)
     if not getattr(model.student["backbone"], "model_parallel", False):
         model = model.to(torch.device("cuda"))
+        # channels_last for 2D
+        if bool(cfg.train.get("channels_last", False)) and not bool(cfg.student.get("is_3d", False)):
+            model = model.to(memory_format=torch.channels_last)
+    # torch.compile (PT 2.0+)
+    if bool(cfg.train.get("torch_compile", False)):
+        mode = str(cfg.train.get("torch_compile_mode", "reduce-overhead"))
+        try:
+            model = torch.compile(model, mode=mode)
+        except Exception as e:
+            logger.warning(f"torch.compile failed: {e}")
     model.prepare_for_distributed_training()
 
     logger.info("Model:\n{}".format(model))

--- a/dinov2/train/train.py
+++ b/dinov2/train/train.py
@@ -198,34 +198,47 @@ def do_train(cfg, model, resume=False):
     )
 
     # setup data loader
-
-    dataset = make_dataset(
-        dataset_str=cfg.train.dataset_path,
-        transform=data_transform,
-        target_transform=lambda _: (),
-    )
-    # sampler_type = SamplerType.INFINITE
-    sampler_type = SamplerType.SHARDED_INFINITE
     # Set PyTorch multiprocessing sharing strategy to reduce shared memory pressure if configured
     if hasattr(cfg.train, "shm_sharing_strategy"):
         import torch.multiprocessing as mp
 
         mp.set_sharing_strategy(str(cfg.train.shm_sharing_strategy))
 
-    data_loader = make_data_loader(
-        dataset=dataset,
-        batch_size=cfg.train.batch_size_per_gpu,
-        num_workers=cfg.train.num_workers,
-        shuffle=True,
-        seed=start_iter,  # TODO: Fix this -- cfg.train.seed
-        sampler_type=sampler_type,
-        sampler_advance=0,  # TODO(qas): fix this -- start_iter * cfg.train.batch_size_per_gpu,
-        drop_last=True,
-        collate_fn=collate_fn,
-        pin_memory=bool(cfg.train.get("pin_memory", True)),
-        prefetch_factor=int(cfg.train.get("prefetch_factor", 2)),
-        persistent_workers=bool(cfg.train.get("persistent_workers", False)),
-    )
+    if bool(cfg.train.get("use_xarray", False)):
+        from dinov2.data.loaders import make_xarray_loader
+
+        data_loader = make_xarray_loader(
+            ds_path=str(cfg.train.xarray.dataset_path),
+            image_var=str(cfg.train.xarray.image_var),
+            target_var=str(cfg.train.xarray.target_var) if cfg.train.xarray.target_var else None,
+            batch_size=int(cfg.train.batch_size_per_gpu),
+            num_workers=int(cfg.train.num_workers),
+            to_chw=bool(cfg.train.xarray.to_chw),
+            normalize=bool(cfg.train.xarray.normalize),
+            chunks=dict(cfg.train.xarray.chunks) if cfg.train.xarray.chunks else None,
+        )
+    else:
+        dataset = make_dataset(
+            dataset_str=cfg.train.dataset_path,
+            transform=data_transform,
+            target_transform=lambda _: (),
+        )
+        # sampler_type = SamplerType.INFINITE
+        sampler_type = SamplerType.SHARDED_INFINITE
+        data_loader = make_data_loader(
+            dataset=dataset,
+            batch_size=cfg.train.batch_size_per_gpu,
+            num_workers=cfg.train.num_workers,
+            shuffle=True,
+            seed=start_iter,  # TODO: Fix this -- cfg.train.seed
+            sampler_type=sampler_type,
+            sampler_advance=0,  # TODO(qas): fix this -- start_iter * cfg.train.batch_size_per_gpu,
+            drop_last=True,
+            collate_fn=collate_fn,
+            pin_memory=bool(cfg.train.get("pin_memory", True)),
+            prefetch_factor=int(cfg.train.get("prefetch_factor", 2)),
+            persistent_workers=bool(cfg.train.get("persistent_workers", False)),
+        )
 
     # training loop
 

--- a/dinov2/train/train.py
+++ b/dinov2/train/train.py
@@ -216,6 +216,7 @@ def do_train(cfg, model, resume=False):
             to_chw=bool(cfg.train.xarray.to_chw),
             normalize=bool(cfg.train.xarray.normalize),
             chunks=dict(cfg.train.xarray.chunks) if cfg.train.xarray.chunks else None,
+            tiling=dict(cfg.train.tiling) if hasattr(cfg.train, "tiling") else None,
         )
     else:
         dataset = make_dataset(

--- a/dinov2/train/train.py
+++ b/dinov2/train/train.py
@@ -223,6 +223,18 @@ def do_train(cfg, model, resume=False):
             transform=data_transform,
             target_transform=lambda _: (),
         )
+        # Optional tiling for large inputs
+        if bool(cfg.train.get("tiling", {}).get("enabled", False)):
+            from dinov2.data.loaders import make_tiled_iterable_dataset
+
+            dataset = make_tiled_iterable_dataset(
+                dataset=dataset,
+                is_3d=bool(cfg.train.tiling.is_3d),
+                tile_size=tuple(cfg.train.tiling.tile_size),
+                stride=tuple(cfg.train.tiling.stride),
+                drop_last_tiles=bool(cfg.train.tiling.drop_last_tiles),
+                transform=dataset.transform,
+            )
         # sampler_type = SamplerType.INFINITE
         sampler_type = SamplerType.SHARDED_INFINITE
         data_loader = make_data_loader(

--- a/tests/test_model_parallel.py
+++ b/tests/test_model_parallel.py
@@ -1,0 +1,83 @@
+import pytest
+import torch
+
+from dinov2.models.vision_transformer import DinoVisionTransformer
+
+
+def make_vit_mp(depth=8, embed_dim=64, num_heads=4, devices=None):
+    return DinoVisionTransformer(
+        img_size=64,
+        patch_size=16,
+        in_chans=3,
+        embed_dim=embed_dim,
+        depth=depth,
+        num_heads=num_heads,
+        mlp_ratio=2.0,
+        block_chunks=0,
+        mp_devices=devices,
+    )
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 4, reason="requires >= 4 CUDA devices")
+def test_mp_device_placement():
+    devices = [torch.device(f"cuda:{i}") for i in range(4)]
+    model = make_vit_mp(depth=8, devices=devices)
+
+    assert getattr(model, "model_parallel", False), "model_parallel flag not set"
+    assert hasattr(model, "_block_devices") and len(model._block_devices) == model.n_blocks
+
+    # stage split mapping correctness
+    for stage_idx, (s, e) in enumerate(model.stage_splits):
+        for i in range(s, e):
+            assert model._block_devices[i] == devices[stage_idx]
+
+    # module placements
+    first_block_param_dev = next(model.blocks[0].parameters()).device
+    last_block_param_dev = next(model.blocks[-1].parameters()).device
+    assert first_block_param_dev == devices[0]
+    assert last_block_param_dev == devices[-1]
+    assert next(model.patch_embed.parameters()).device == devices[0]
+    assert next(model.norm.parameters()).device == devices[-1]
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 4, reason="requires >= 4 CUDA devices")
+def test_mp_forward_and_backward_single_input():
+    devices = [torch.device(f"cuda:{i}") for i in range(4)]
+    model = make_vit_mp(depth=8, devices=devices)
+    model.train()
+
+    x = torch.randn(2, 3, 64, 64)  # CPU input, model will move across devices
+    out = model(x, is_training=True)
+
+    assert isinstance(out, dict)
+    assert out["x_norm_clstoken"].device == devices[-1]
+    assert out["x_prenorm"].device == devices[-1]
+
+    loss = out["x_norm_clstoken"].float().pow(2).mean()
+    loss.backward()
+
+    # Ensure grads flowed to early and late blocks
+    assert any(p.grad is not None for p in model.blocks[0].parameters())
+    assert any(p.grad is not None for p in model.blocks[-1].parameters())
+
+
+def test_non_mp_forward_cpu():
+    model = DinoVisionTransformer(
+        img_size=32,
+        patch_size=16,
+        in_chans=3,
+        embed_dim=32,
+        depth=2,
+        num_heads=4,
+        mlp_ratio=2.0,
+        block_chunks=0,
+    )
+    model.eval()
+
+    x = torch.randn(1, 3, 32, 32)
+    out = model(x, is_training=True)
+    assert isinstance(out, dict)
+    assert out["x_norm_clstoken"].shape == (1, 32)
+
+    y = model(x)  # inference path
+    assert y.shape == (1, 32)


### PR DESCRIPTION
Implement model parallelism for `DinoVisionTransformer` and add multi-node training support.

This enables training of larger models by partitioning layers across multiple GPUs within a node and extending this to a multi-node setup, with each node utilizing model parallelism. It includes device placement logic, input/output device transfers, inter-node gradient synchronization, and appropriate FSDP/checkpointing bypasses for model-parallel configurations.

---
<a href="https://cursor.com/background-agent?bcId=bc-8f991859-3afe-4992-8c3c-58c5fa2ad4d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8f991859-3afe-4992-8c3c-58c5fa2ad4d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

